### PR TITLE
Support disk size

### DIFF
--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -66,6 +66,11 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         return False
     if q.spot is not None and i.spot != q.spot:
         return False
+    if i.disk_size is not None:
+        if q.min_disk_size and i.disk_size < q.min_disk_size:
+            return False
+        if q.max_disk_size and i.disk_size > q.max_disk_size:
+            return False
     return True
 
 

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -59,18 +59,13 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         q.max_total_gpu_memory,
     ):
         return False
-    # TODO(egor-s): add disk_size to CatalogItem
-    # if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
-    #     return False
+    if i.disk_size is not None:
+        if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
+            return False
     if not is_between(i.price, q.min_price, q.max_price):
         return False
     if q.spot is not None and i.spot != q.spot:
         return False
-    if i.disk_size is not None:
-        if q.min_disk_size and i.disk_size < q.min_disk_size:
-            return False
-        if q.max_disk_size and i.disk_size > q.max_disk_size:
-            return False
     return True
 
 

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -59,12 +59,18 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         q.max_total_gpu_memory,
     ):
         return False
-    if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
-        return False
+    # TODO(egor-s): add disk_size to CatalogItem
+    # if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
+    #     return False
     if not is_between(i.price, q.min_price, q.max_price):
         return False
     if q.spot is not None and i.spot != q.spot:
         return False
+    if i.disk_size is not None:
+        if q.min_disk_size and i.disk_size < q.min_disk_size:
+            return False
+        if q.max_disk_size and i.disk_size > q.max_disk_size:
+            return False
     return True
 
 

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -59,18 +59,12 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         q.max_total_gpu_memory,
     ):
         return False
-    # TODO(egor-s): add disk_size to CatalogItem
-    # if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
-    #     return False
+    if not is_between(i.disk_size, q.min_disk_size, q.max_disk_size):
+        return False
     if not is_between(i.price, q.min_price, q.max_price):
         return False
     if q.spot is not None and i.spot != q.spot:
         return False
-    if i.disk_size is not None:
-        if q.min_disk_size and i.disk_size < q.min_disk_size:
-            return False
-        if q.max_disk_size and i.disk_size > q.max_disk_size:
-            return False
     return True
 
 

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -73,10 +73,7 @@ class CatalogItem(RawCatalogItem):
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":
-        raw = asdict(RawCatalogItem.from_dict(v))
-        if not raw.disk_size:
-            raw.disk_size = 100.0  # the default value for backward compatibility
-        return CatalogItem(provider=provider, **raw)
+        return CatalogItem(provider=provider, **asdict(RawCatalogItem.from_dict(v)))
 
 
 @dataclass

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -10,7 +10,7 @@ def bool_loader(x: Union[bool, str]) -> bool:
     return x.lower() == "true"
 
 
-@dataclass(kw_only=True)
+@dataclass
 class RawCatalogItem:
     instance_name: Optional[str]
     location: Optional[str]
@@ -42,7 +42,7 @@ class RawCatalogItem:
         return asdict(self)
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CatalogItem(RawCatalogItem):
     """
     Attributes:
@@ -69,7 +69,7 @@ class CatalogItem(RawCatalogItem):
     gpu_memory: Optional[float]
     spot: bool
     provider: str
-    disk_size: float = 100.0  # the default value for backward compatibility
+    disk_size: Optional[float]
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -73,10 +73,10 @@ class CatalogItem(RawCatalogItem):
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":
-        raw = RawCatalogItem.from_dict(v)
+        raw = asdict(RawCatalogItem.from_dict(v))
         if not raw.disk_size:
             raw.disk_size = 100.0  # the default value for backward compatibility
-        return CatalogItem(provider=provider, **asdict(raw))
+        return CatalogItem(provider=provider, **raw)
 
 
 @dataclass

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -73,7 +73,10 @@ class CatalogItem(RawCatalogItem):
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":
-        return CatalogItem(provider=provider, **asdict(RawCatalogItem.from_dict(v)))
+        raw = asdict(RawCatalogItem.from_dict(v))
+        if not raw.disk_size:
+            raw.disk_size = 100.0  # the default value for backward compatibility
+        return CatalogItem(provider=provider, **raw)
 
 
 @dataclass

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -10,7 +10,7 @@ def bool_loader(x: Union[bool, str]) -> bool:
     return x.lower() == "true"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RawCatalogItem:
     instance_name: Optional[str]
     location: Optional[str]
@@ -42,7 +42,7 @@ class RawCatalogItem:
         return asdict(self)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CatalogItem(RawCatalogItem):
     """
     Attributes:
@@ -69,7 +69,7 @@ class CatalogItem(RawCatalogItem):
     gpu_memory: Optional[float]
     spot: bool
     provider: str
-    disk_size: Optional[float]
+    disk_size: float = 100.0  # the default value for backward compatibility
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -10,7 +10,7 @@ def bool_loader(x: Union[bool, str]) -> bool:
     return x.lower() == "true"
 
 
-@dataclass(kw_only=True)
+@dataclass
 class RawCatalogItem:
     instance_name: Optional[str]
     location: Optional[str]
@@ -42,7 +42,7 @@ class RawCatalogItem:
         return asdict(self)
 
 
-@dataclass(kw_only=True)
+@dataclass
 class CatalogItem(RawCatalogItem):
     """
     Attributes:
@@ -59,6 +59,7 @@ class CatalogItem(RawCatalogItem):
         disk_size: size of disk in GB
     """
 
+    provider: str
     instance_name: str
     location: str
     price: float
@@ -68,8 +69,7 @@ class CatalogItem(RawCatalogItem):
     gpu_name: Optional[str]
     gpu_memory: Optional[float]
     spot: bool
-    provider: str
-    disk_size: float = 100.0  # the default value for backward compatibility
+    disk_size: float
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -21,6 +21,7 @@ class RawCatalogItem:
     gpu_name: Optional[str]
     gpu_memory: Optional[float]
     spot: Optional[bool]
+    disk_size: Optional[float]
 
     @staticmethod
     def from_dict(v: dict) -> "RawCatalogItem":
@@ -34,6 +35,7 @@ class RawCatalogItem:
             gpu_name=empty_as_none(v.get("gpu_name")),
             gpu_memory=empty_as_none(v.get("gpu_memory"), loader=float),
             spot=empty_as_none(v.get("spot"), loader=bool_loader),
+            disk_size=empty_as_none(v.get("disk_size"), loader=float),
         )
 
     def dict(self) -> Dict[str, Union[str, int, float, bool, None]]:
@@ -54,6 +56,7 @@ class CatalogItem(RawCatalogItem):
         gpu_memory: amount of GPU VRAM in GB for each GPU
         spot: whether the instance is a spot instance
         provider: name of the provider
+        disk_size: size of disk in GB
     """
 
     instance_name: str
@@ -66,6 +69,7 @@ class CatalogItem(RawCatalogItem):
     gpu_memory: Optional[float]
     spot: bool
     provider: str
+    disk_size: Optional[float]
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -10,7 +10,7 @@ def bool_loader(x: Union[bool, str]) -> bool:
     return x.lower() == "true"
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RawCatalogItem:
     instance_name: Optional[str]
     location: Optional[str]
@@ -42,7 +42,7 @@ class RawCatalogItem:
         return asdict(self)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class CatalogItem(RawCatalogItem):
     """
     Attributes:
@@ -59,7 +59,6 @@ class CatalogItem(RawCatalogItem):
         disk_size: size of disk in GB
     """
 
-    provider: str
     instance_name: str
     location: str
     price: float
@@ -69,7 +68,8 @@ class CatalogItem(RawCatalogItem):
     gpu_name: Optional[str]
     gpu_memory: Optional[float]
     spot: bool
-    disk_size: float
+    provider: str
+    disk_size: float = 100.0  # the default value for backward compatibility
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -73,10 +73,10 @@ class CatalogItem(RawCatalogItem):
 
     @staticmethod
     def from_dict(v: dict, *, provider: Optional[str] = None) -> "CatalogItem":
-        raw = asdict(RawCatalogItem.from_dict(v))
+        raw = RawCatalogItem.from_dict(v)
         if not raw.disk_size:
             raw.disk_size = 100.0  # the default value for backward compatibility
-        return CatalogItem(provider=provider, **raw)
+        return CatalogItem(provider=provider, **asdict(raw))
 
 
 @dataclass

--- a/src/gpuhunt/providers/aws.py
+++ b/src/gpuhunt/providers/aws.py
@@ -98,7 +98,7 @@ class AWSProvider(AbstractProvider):
                     spot=False,
                     gpu_name=None,
                     gpu_memory=None,
-                    disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
+                    disk_size=None,
                 )
                 offers.append(offer)
         self.fill_gpu_details(offers)

--- a/src/gpuhunt/providers/aws.py
+++ b/src/gpuhunt/providers/aws.py
@@ -98,6 +98,7 @@ class AWSProvider(AbstractProvider):
                     spot=False,
                     gpu_name=None,
                     gpu_memory=None,
+                    disk_size=None,
                 )
                 offers.append(offer)
         self.fill_gpu_details(offers)

--- a/src/gpuhunt/providers/aws.py
+++ b/src/gpuhunt/providers/aws.py
@@ -98,7 +98,7 @@ class AWSProvider(AbstractProvider):
                     spot=False,
                     gpu_name=None,
                     gpu_memory=None,
-                    disk_size=None,
+                    disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
                 )
                 offers.append(offer)
         self.fill_gpu_details(offers)

--- a/src/gpuhunt/providers/azure.py
+++ b/src/gpuhunt/providers/azure.py
@@ -153,13 +153,15 @@ class AzureProvider(AbstractProvider):
                     gpu_count=None,
                     gpu_name=None,
                     gpu_memory=None,
-                    disk_size=None,
+                    disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
                 )
                 offers.append(offer)
-        offers = self.fill_details(offers)
+        offers = self.fill_details(query_filter, offers)
         return sorted(offers, key=lambda i: i.price)
 
-    def fill_details(self, offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
+    def fill_details(
+        self, query_filter: Optional[QueryFilter], offers: List[RawCatalogItem]
+    ) -> List[RawCatalogItem]:
         logger.info("Fetching instance details")
         instances = {}
         resources = self.client.resource_skus.list()
@@ -183,7 +185,7 @@ class AzureProvider(AbstractProvider):
                 location=None,
                 price=None,
                 spot=None,
-                disk_size=None,
+                disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
             )
         with_details = []
         without_details = []

--- a/src/gpuhunt/providers/azure.py
+++ b/src/gpuhunt/providers/azure.py
@@ -153,15 +153,13 @@ class AzureProvider(AbstractProvider):
                     gpu_count=None,
                     gpu_name=None,
                     gpu_memory=None,
-                    disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
+                    disk_size=None,
                 )
                 offers.append(offer)
-        offers = self.fill_details(query_filter, offers)
+        offers = self.fill_details(offers)
         return sorted(offers, key=lambda i: i.price)
 
-    def fill_details(
-        self, query_filter: Optional[QueryFilter], offers: List[RawCatalogItem]
-    ) -> List[RawCatalogItem]:
+    def fill_details(self, offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
         logger.info("Fetching instance details")
         instances = {}
         resources = self.client.resource_skus.list()
@@ -185,7 +183,7 @@ class AzureProvider(AbstractProvider):
                 location=None,
                 price=None,
                 spot=None,
-                disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
+                disk_size=None,
             )
         with_details = []
         without_details = []

--- a/src/gpuhunt/providers/azure.py
+++ b/src/gpuhunt/providers/azure.py
@@ -153,6 +153,7 @@ class AzureProvider(AbstractProvider):
                     gpu_count=None,
                     gpu_name=None,
                     gpu_memory=None,
+                    disk_size=None,
                 )
                 offers.append(offer)
         offers = self.fill_details(offers)
@@ -182,6 +183,7 @@ class AzureProvider(AbstractProvider):
                 location=None,
                 price=None,
                 spot=None,
+                disk_size=None,
             )
         with_details = []
         without_details = []

--- a/src/gpuhunt/providers/datacrunch.py
+++ b/src/gpuhunt/providers/datacrunch.py
@@ -24,7 +24,7 @@ class DataCrunchProvider(AbstractProvider):
 
         spots = (True, False)
         location_codes = [loc["code"] for loc in locations]
-        instances = generate_instances(query_filter, spots, location_codes, instance_types)
+        instances = generate_instances(spots, location_codes, instance_types)
 
         return sorted(instances, key=lambda x: x.price)
 
@@ -39,24 +39,16 @@ class DataCrunchProvider(AbstractProvider):
 
 
 def generate_instances(
-    query_filter: Optional[QueryFilter],
-    spots: Iterable[bool],
-    location_codes: Iterable[str],
-    instance_types: Iterable[InstanceType],
+    spots: Iterable[bool], location_codes: Iterable[str], instance_types: Iterable[InstanceType]
 ) -> List[RawCatalogItem]:
     instances = []
     for spot, location, instance in itertools.product(spots, location_codes, instance_types):
-        item = transform_instance(query_filter, copy.copy(instance), spot, location)
+        item = transform_instance(copy.copy(instance), spot, location)
         instances.append(RawCatalogItem.from_dict(item))
     return instances
 
 
-def transform_instance(
-    query_filter: Optional[QueryFilter],
-    instance: InstanceType,
-    spot: bool,
-    location: str,
-) -> dict:
+def transform_instance(instance: InstanceType, spot: bool, location: str) -> dict:
     gpu_memory = 0
     if instance.gpu["number_of_gpus"]:
         gpu_memory = instance.gpu_memory["size_in_gigabytes"] / instance.gpu["number_of_gpus"]
@@ -70,7 +62,6 @@ def transform_instance(
         gpu_count=instance.gpu["number_of_gpus"],
         gpu_name=gpu_name(instance.gpu["description"]),
         gpu_memory=gpu_memory,
-        disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
     )
     return raw
 

--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -91,6 +91,7 @@ class GCPProvider(AbstractProvider):
                         gpu_memory=gpu.memory if gpu else None,
                         price=None,
                         spot=None,
+                        disk_size=None,
                     )
                     instances.append(instance)
         return instances

--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -55,7 +55,9 @@ class GCPProvider(AbstractProvider):
         self.regions_client = compute_v1.RegionsClient()
         self.cloud_catalog_client = billing_v1.CloudCatalogClient()
 
-    def list_preconfigured_instances(self) -> List[RawCatalogItem]:
+    def list_preconfigured_instances(
+        self, query_filter: Optional[QueryFilter]
+    ) -> List[RawCatalogItem]:
         instances = []
         for region in self.regions_client.list(project=self.project):
             for zone_url in region.zones:
@@ -91,7 +93,7 @@ class GCPProvider(AbstractProvider):
                         gpu_memory=gpu.memory if gpu else None,
                         price=None,
                         spot=None,
-                        disk_size=None,
+                        disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
                     )
                     instances.append(instance)
         return instances
@@ -208,7 +210,7 @@ class GCPProvider(AbstractProvider):
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
     ) -> List[RawCatalogItem]:
-        instances = self.list_preconfigured_instances()
+        instances = self.list_preconfigured_instances(query_filter)
         self.add_gpus(instances)
         offers = self.fill_prices(instances)
         return sorted(offers, key=lambda i: i.price)

--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -55,9 +55,7 @@ class GCPProvider(AbstractProvider):
         self.regions_client = compute_v1.RegionsClient()
         self.cloud_catalog_client = billing_v1.CloudCatalogClient()
 
-    def list_preconfigured_instances(
-        self, query_filter: Optional[QueryFilter]
-    ) -> List[RawCatalogItem]:
+    def list_preconfigured_instances(self) -> List[RawCatalogItem]:
         instances = []
         for region in self.regions_client.list(project=self.project):
             for zone_url in region.zones:
@@ -93,7 +91,7 @@ class GCPProvider(AbstractProvider):
                         gpu_memory=gpu.memory if gpu else None,
                         price=None,
                         spot=None,
-                        disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
+                        disk_size=None,
                     )
                     instances.append(instance)
         return instances
@@ -210,7 +208,7 @@ class GCPProvider(AbstractProvider):
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
     ) -> List[RawCatalogItem]:
-        instances = self.list_preconfigured_instances(query_filter)
+        instances = self.list_preconfigured_instances()
         self.add_gpus(instances)
         offers = self.fill_prices(instances)
         return sorted(offers, key=lambda i: i.price)

--- a/src/gpuhunt/providers/lambdalabs.py
+++ b/src/gpuhunt/providers/lambdalabs.py
@@ -52,6 +52,7 @@ class LambdaLabsProvider(AbstractProvider):
                 gpu_memory=gpu_memory,
                 spot=False,
                 location=None,
+                disk_size=None,
             )
             offers.append(offer)
         offers = self.add_regions(offers)

--- a/src/gpuhunt/providers/lambdalabs.py
+++ b/src/gpuhunt/providers/lambdalabs.py
@@ -46,13 +46,13 @@ class LambdaLabsProvider(AbstractProvider):
                 instance_name=instance["name"],
                 price=instance["price_cents_per_hour"] / 100,
                 cpu=instance["specs"]["vcpus"],
-                memory=float(instance["specs"]["memory_gib"]),
+                memory=float(instance["specs"]["memory_gib"]) * 1.074,
                 gpu_count=gpu_count,
                 gpu_name=gpu_name,
                 gpu_memory=gpu_memory,
                 spot=False,
                 location=None,
-                disk_size=None,
+                disk_size=float(instance["specs"]["storage_gib"]) * 1.074,
             )
             offers.append(offer)
         offers = self.add_regions(offers)

--- a/src/gpuhunt/providers/nebius.py
+++ b/src/gpuhunt/providers/nebius.py
@@ -66,7 +66,27 @@ GPU_PLATFORMS = {
 }
 CPU_PLATFORMS = {
     "standard-v2": {
-        "cpus": [2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60],
+        "cpus": [
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            20,
+            24,
+            28,
+            32,
+            36,
+            40,
+            44,
+            48,
+            52,
+            56,
+            60,
+        ],
         "ratios": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
     }
 }
@@ -122,6 +142,7 @@ class NebiusProvider(AbstractProvider):
                         gpu_name=gpu_name,
                         gpu_memory=gpu_memory,
                         spot=False,
+                        disk_size=None,
                     )
                 )
         return items
@@ -146,6 +167,7 @@ class NebiusProvider(AbstractProvider):
                             gpu_name=None,
                             gpu_memory=None,
                             spot=False,
+                            disk_size=None,
                         )
                     )
         return items

--- a/src/gpuhunt/providers/nebius.py
+++ b/src/gpuhunt/providers/nebius.py
@@ -114,15 +114,13 @@ class NebiusProvider(AbstractProvider):
             if page_token is None:
                 break
         platform_resources = self.aggregate_skus(skus)
-        offers = self.get_gpu_platforms(query_filter, zone, platform_resources)
-        offers += self.get_cpu_platforms(query_filter, zone, platform_resources)
+        offers = self.get_gpu_platforms(zone, platform_resources)
+        offers += self.get_cpu_platforms(zone, platform_resources)
         return sorted(offers, key=lambda i: i.price)
 
     @staticmethod
     def get_gpu_platforms(
-        query_filter: Optional[QueryFilter],
-        zone: str,
-        platform_resources: "PlatformResourcePrice",
+        zone: str, platform_resources: "PlatformResourcePrice"
     ) -> List[RawCatalogItem]:
         items = []
         for platform, presets in GPU_PLATFORMS.items():
@@ -144,16 +142,14 @@ class NebiusProvider(AbstractProvider):
                         gpu_name=gpu_name,
                         gpu_memory=gpu_memory,
                         spot=False,
-                        disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
+                        disk_size=None,
                     )
                 )
         return items
 
     @staticmethod
     def get_cpu_platforms(
-        query_filter: Optional[QueryFilter],
-        zone: str,
-        platform_resources: "PlatformResourcePrice",
+        zone: str, platform_resources: "PlatformResourcePrice"
     ) -> List[RawCatalogItem]:
         items = []
         for platform, limits in CPU_PLATFORMS.items():
@@ -171,9 +167,7 @@ class NebiusProvider(AbstractProvider):
                             gpu_name=None,
                             gpu_memory=None,
                             spot=False,
-                            disk_size=query_filter.min_disk_size or 100.0
-                            if query_filter
-                            else 100.0,
+                            disk_size=None,
                         )
                     )
         return items

--- a/src/gpuhunt/providers/nebius.py
+++ b/src/gpuhunt/providers/nebius.py
@@ -114,13 +114,15 @@ class NebiusProvider(AbstractProvider):
             if page_token is None:
                 break
         platform_resources = self.aggregate_skus(skus)
-        offers = self.get_gpu_platforms(zone, platform_resources)
-        offers += self.get_cpu_platforms(zone, platform_resources)
+        offers = self.get_gpu_platforms(query_filter, zone, platform_resources)
+        offers += self.get_cpu_platforms(query_filter, zone, platform_resources)
         return sorted(offers, key=lambda i: i.price)
 
     @staticmethod
     def get_gpu_platforms(
-        zone: str, platform_resources: "PlatformResourcePrice"
+        query_filter: Optional[QueryFilter],
+        zone: str,
+        platform_resources: "PlatformResourcePrice",
     ) -> List[RawCatalogItem]:
         items = []
         for platform, presets in GPU_PLATFORMS.items():
@@ -142,14 +144,16 @@ class NebiusProvider(AbstractProvider):
                         gpu_name=gpu_name,
                         gpu_memory=gpu_memory,
                         spot=False,
-                        disk_size=None,
+                        disk_size=query_filter.min_disk_size or 100.0 if query_filter else 100.0,
                     )
                 )
         return items
 
     @staticmethod
     def get_cpu_platforms(
-        zone: str, platform_resources: "PlatformResourcePrice"
+        query_filter: Optional[QueryFilter],
+        zone: str,
+        platform_resources: "PlatformResourcePrice",
     ) -> List[RawCatalogItem]:
         items = []
         for platform, limits in CPU_PLATFORMS.items():
@@ -167,7 +171,9 @@ class NebiusProvider(AbstractProvider):
                             gpu_name=None,
                             gpu_memory=None,
                             spot=False,
-                            disk_size=None,
+                            disk_size=query_filter.min_disk_size or 100.0
+                            if query_filter
+                            else 100.0,
                         )
                     )
         return items

--- a/src/gpuhunt/providers/tensordock.py
+++ b/src/gpuhunt/providers/tensordock.py
@@ -201,6 +201,7 @@ class TensorDockProvider(AbstractProvider):
                     gpu_count=gpu_count,
                     gpu_memory=float(gpu_info["vram"]),
                     spot=False,
+                    disk_size=disk_size,
                 )
                 offers.append(offer)
                 break  # stop increasing gpu count

--- a/src/gpuhunt/providers/vastai.py
+++ b/src/gpuhunt/providers/vastai.py
@@ -61,6 +61,7 @@ class VastAIProvider(AbstractProvider):
                 gpu_name=gpu_name,
                 gpu_memory=float(int(offer["gpu_ram"] / kilo)),
                 spot=False,
+                disk_size=offer["disk_space"],
             )
             instance_offers.append(ondemand_offer)
 

--- a/src/tests/_internal/test_catalog.py
+++ b/src/tests/_internal/test_catalog.py
@@ -50,6 +50,7 @@ def catalog_item(**kwargs) -> Union[CatalogItem, RawCatalogItem]:
         location="location",
         price=1,
         spot=False,
+        disk_size=None,
     )
     values.update(kwargs)
     if "provider" in values:

--- a/src/tests/_internal/test_constraints.py
+++ b/src/tests/_internal/test_constraints.py
@@ -19,6 +19,7 @@ def item() -> CatalogItem:
         gpu_memory=40.0,
         spot=False,
         provider="aws",
+        disk_size=None,
     )
 
 
@@ -35,6 +36,7 @@ def cpu_items() -> List[CatalogItem]:
         gpu_memory=0.0,
         spot=False,
         provider="datacrunch",
+        disk_size=None,
     )
     nebius = CatalogItem(
         instance_name="standard-v2",
@@ -47,6 +49,7 @@ def cpu_items() -> List[CatalogItem]:
         gpu_memory=None,
         spot=False,
         provider="nebius",
+        disk_size=None,
     )
     return [datacrunch, nebius]
 
@@ -117,6 +120,7 @@ class TestMatches:
             gpu_memory=8.0,
             spot=False,
             provider="aws",
+            disk_size=None,
         )
         assert matches(item, QueryFilter(gpu_name=["RTX3060TI"]))
 

--- a/src/tests/providers/test_datacrunch.py
+++ b/src/tests/providers/test_datacrunch.py
@@ -19,7 +19,12 @@ from gpuhunt.providers.datacrunch import (
 def raw_instance_types() -> List[dict]:
     # datacrunch.instance_types.get()
     one_gpu = {
-        "best_for": ["Gargantuan ML models", "Multi-GPU training", "FP64 HPC", "NVLINK"],
+        "best_for": [
+            "Gargantuan ML models",
+            "Multi-GPU training",
+            "FP64 HPC",
+            "NVLINK",
+        ],
         "cpu": {"description": "30 CPU", "number_of_cores": 30},
         "deploy_warning": "H100: Use Nvidia driver 535 or higher for best performance",
         "description": "Dedicated Hardware Instance",
@@ -73,7 +78,12 @@ def raw_instance_types() -> List[dict]:
     }
 
     minimal = {
-        "best_for": ["Small ML models", "Multi-GPU training", "FP64 calculations", "NVLINK"],
+        "best_for": [
+            "Small ML models",
+            "Multi-GPU training",
+            "FP64 calculations",
+            "NVLINK",
+        ],
         "cpu": {"description": "6 CPU", "number_of_cores": 6},
         "deploy_warning": None,
         "description": "Dedicated Hardware Instance",
@@ -215,6 +225,7 @@ def test_available_query(mocker, raw_instance_types):
         gpu_memory=80.0,
         spot=True,
         provider="datacrunch",
+        disk_size=None,
     )
     expected_non_spot = CatalogItem(
         instance_name="1H100.80S.30V",
@@ -227,6 +238,7 @@ def test_available_query(mocker, raw_instance_types):
         gpu_memory=80.0,
         spot=False,
         provider="datacrunch",
+        disk_size=None,
     )
     assert [r for r in query_result if r.spot] == [expected_spot]
     assert [r for r in query_result if not r.spot] == [expected_non_spot]
@@ -264,6 +276,7 @@ def test_available_query_with_instance(mocker, raw_instance_types):
         gpu_memory=16.0,
         spot=True,
         provider="datacrunch",
+        disk_size=None,
     )
     expected_non_spot = CatalogItem(
         instance_name="1V100.6V",
@@ -276,6 +289,7 @@ def test_available_query_with_instance(mocker, raw_instance_types):
         gpu_memory=16.0,
         spot=False,
         provider="datacrunch",
+        disk_size=None,
     )
 
     assert [r for r in query_result if r.spot] == [expected_spot]
@@ -297,6 +311,7 @@ def test_transform_instance(raw_instance_types):
         gpu_name="A6000",
         gpu_memory=96 / 2,
         spot=True,
+        disk_size=None,
     )
 
     assert RawCatalogItem.from_dict(item) == expected
@@ -317,6 +332,7 @@ def test_cpu_instance(raw_instance_types):
         gpu_name=None,
         gpu_memory=0,
         spot=False,
+        disk_size=None,
     )
 
     assert RawCatalogItem.from_dict(item) == expected

--- a/src/tests/providers/test_datacrunch.py
+++ b/src/tests/providers/test_datacrunch.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 
 import gpuhunt._internal.catalog as internal_catalog
-from gpuhunt import Catalog, CatalogItem, QueryFilter, RawCatalogItem
+from gpuhunt import Catalog, CatalogItem, RawCatalogItem
 from gpuhunt.providers.datacrunch import (
     DataCrunchProvider,
     InstanceType,
@@ -171,7 +171,7 @@ def list_available_instances(raw_instance_types, locations):
     spots = (True, False)
     locations = [loc["loc"] for loc in locations]
     instances = [instance_types(raw_instance_types[0])]
-    list_instances = generate_instances(None, spots, locations, instances)
+    list_instances = generate_instances(spots, locations, instances)
 
     assert len(list_instances) == 4
     assert [i.price for i in list_instances if i.spot] == [1, 70] * 2
@@ -225,7 +225,7 @@ def test_available_query(mocker, raw_instance_types):
         gpu_memory=80.0,
         spot=True,
         provider="datacrunch",
-        disk_size=100.0,
+        disk_size=None,
     )
     expected_non_spot = CatalogItem(
         instance_name="1H100.80S.30V",
@@ -238,7 +238,7 @@ def test_available_query(mocker, raw_instance_types):
         gpu_memory=80.0,
         spot=False,
         provider="datacrunch",
-        disk_size=100.0,
+        disk_size=None,
     )
     assert [r for r in query_result if r.spot] == [expected_spot]
     assert [r for r in query_result if not r.spot] == [expected_non_spot]
@@ -276,7 +276,7 @@ def test_available_query_with_instance(mocker, raw_instance_types):
         gpu_memory=16.0,
         spot=True,
         provider="datacrunch",
-        disk_size=100.0,
+        disk_size=None,
     )
     expected_non_spot = CatalogItem(
         instance_name="1V100.6V",
@@ -289,7 +289,7 @@ def test_available_query_with_instance(mocker, raw_instance_types):
         gpu_memory=16.0,
         spot=False,
         provider="datacrunch",
-        disk_size=100.0,
+        disk_size=None,
     )
 
     assert [r for r in query_result if r.spot] == [expected_spot]
@@ -299,12 +299,7 @@ def test_available_query_with_instance(mocker, raw_instance_types):
 def test_transform_instance(raw_instance_types):
     location = "ICE-01"
     is_spot = True
-    item = transform_instance(
-        QueryFilter(min_disk_size=150.0),
-        instance_types(raw_instance_types[1]),
-        is_spot,
-        location,
-    )
+    item = transform_instance(instance_types(raw_instance_types[1]), is_spot, location)
 
     expected = RawCatalogItem(
         instance_name="2A6000.20V",
@@ -316,7 +311,7 @@ def test_transform_instance(raw_instance_types):
         gpu_name="A6000",
         gpu_memory=96 / 2,
         spot=True,
-        disk_size=150.0,
+        disk_size=None,
     )
 
     assert RawCatalogItem.from_dict(item) == expected
@@ -325,7 +320,7 @@ def test_transform_instance(raw_instance_types):
 def test_cpu_instance(raw_instance_types):
     location = "ICE-01"
     is_spot = False
-    item = transform_instance(None, instance_types(raw_instance_types[2]), is_spot, location)
+    item = transform_instance(instance_types(raw_instance_types[2]), is_spot, location)
 
     expected = RawCatalogItem(
         instance_name="CPU.120V.480G",
@@ -337,7 +332,7 @@ def test_cpu_instance(raw_instance_types):
         gpu_name=None,
         gpu_memory=0,
         spot=False,
-        disk_size=100.0,
+        disk_size=None,
     )
 
     assert RawCatalogItem.from_dict(item) == expected

--- a/src/tests/providers/test_tensordock.py
+++ b/src/tests/providers/test_tensordock.py
@@ -87,7 +87,7 @@ class TestTensorDockMinimalConfiguration:
 
 
 def make_offers(
-    specs: dict, cpu: int, memory: int, disk_size: int, gpu_count: int
+    specs: dict, cpu: int, memory: float, disk_size: float, gpu_count: int
 ) -> List[RawCatalogItem]:
     gpu = list(specs["gpu"].values())[0]
     price = cpu * specs["cpu"]["price"]
@@ -105,6 +105,6 @@ def make_offers(
             gpu_name="L40",
             gpu_memory=gpu["vram"],
             spot=False,
-            disk_size=None,
+            disk_size=disk_size,
         )
     ]

--- a/src/tests/providers/test_tensordock.py
+++ b/src/tests/providers/test_tensordock.py
@@ -105,5 +105,6 @@ def make_offers(
             gpu_name="L40",
             gpu_memory=gpu["vram"],
             spot=False,
+            disk_size=None,
         )
     ]


### PR DESCRIPTION
Initial support for disk size.

Now `CatalogItem` has `disk_size` (optional).  If not set, the disk size is not pre-defined and can be specified when an instance is created.

Limitations:
 - If `disk_size` is not set, the `price` doesn't include the disk price.