### PR TITLE
Add TPU support in GCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ azure = [
 ]
 gcp = [
     "google-cloud-billing",
-    "google-cloud-compute"
+    "google-cloud-compute",
+    "google-cloud-tpu"
 ]
 nebius = [
     "pyjwt",

--- a/src/gpuhunt/resources/tpu_pricing.json
+++ b/src/gpuhunt/resources/tpu_pricing.json
@@ -1,0 +1,135 @@
+{
+    "TPU v5p": {
+        "us-east5": {
+            "Location": "Ohio",
+            "On Demand (USD)": 4.2000,
+            "1-year Commitment (USD)": 2.9400,
+            "3-year Commitment (USD)": 1.8900,
+            "Spot (USD)": 2.1000
+        },
+        "us-east1": {
+            "Location": "South Carolina",
+            "On Demand (USD)": 4.2000,
+            "1-year Commitment (USD)": 2.9400,
+            "3-year Commitment (USD)": 1.8900,
+            "Spot (USD)": 2.1000
+        }
+    },
+    "TPU v5e": {
+        "us-central1": {
+            "Location": "Iowa",
+            "On Demand (USD)": 1.2000,
+            "1-year Commitment (USD)": 0.8400,
+            "3-year Commitment (USD)": 0.5400,
+            "Spot (USD)": 0.6000
+        },
+        "us-east5": {
+            "Location": "Ohio",
+            "On Demand (USD)": 1.2000,
+            "1-year Commitment (USD)": 0.8400,
+            "3-year Commitment (USD)": 0.5400,
+            "Spot (USD)": 0.6000
+        },
+        "us-south1": {
+            "Location": "Dallas",
+            "On Demand (USD)": 1.2000,
+            "1-year Commitment (USD)": 0.8400,
+            "3-year Commitment (USD)": 0.5400,
+            "Spot (USD)": 0.6000
+        },
+        "us-west1": {
+            "Location": "Oregon",
+            "On Demand (USD)": 1.2000,
+            "1-year Commitment (USD)": 0.8400,
+            "3-year Commitment (USD)": 0.5400,
+            "Spot (USD)": 0.6000
+        },
+        "us-west4": {
+            "Location": "Nevada",
+            "On Demand (USD)": 1.2000,
+            "1-year Commitment (USD)": 0.8400,
+            "3-year Commitment (USD)": 0.5400,
+            "Spot (USD)": 0.6000
+        },
+        "europe-west1": {
+            "Location": "Belgium",
+            "On Demand (USD)": 1.3213,
+            "1-year Commitment (USD)": 0.9249,
+            "3-year Commitment (USD)": 0.5946,
+            "Spot (USD)": 0.6607
+        },
+        "europe-west4": {
+            "Location": "Netherlands",
+            "On Demand (USD)": 1.5600,
+            "1-year Commitment (USD)": 1.0920,
+            "3-year Commitment (USD)": 0.7020,
+            "Spot (USD)": 0.7800
+        },
+        "asia-southeast1": {
+            "Location": "Singapore",
+            "On Demand (USD)": 1.5600,
+            "1-year Commitment (USD)": 1.0920,
+            "3-year Commitment (USD)": 0.7020,
+            "Spot (USD)": 0.7800
+        }
+    },
+    "TPU v4 pod": {
+        "us-central2": {
+            "Location": "Oklahoma",
+            "On Demand (USD)": 3.2200,
+            "1-year Commitment (USD)": 2.0286,
+            "3-year Commitment (USD)": 1.4490,
+            "Spot (USD)": 0.9660
+        }
+    },
+    "TPU v3 pod": {
+        "europe-west4": {
+            "Location": "Netherlands",
+            "On Demand (USD)": 2.0000,
+            "1-year Commitment (USD)": 1.2600,
+            "3-year Commitment (USD)": 0.9000,
+            "Spot (USD)": 0.6000
+        }
+    },
+    "TPU v3 device": {
+        "europe-west4": {
+            "Location": "Netherlands",
+            "On Demand (USD)": 2.2000,
+            "1-year Commitment (USD)": 1.3860,
+            "3-year Commitment (USD)": 0.9900,
+            "Spot (USD)": 0.6600
+        }
+    },
+    "TPU v2 pod": {
+        "us-central1": {
+            "Location": "Iowa",
+            "On Demand (USD)": 1.5000,
+            "1-year Commitment (USD)": 0.9450,
+            "3-year Commitment (USD)": 0.6750,
+            "Spot (USD)": 0.4500
+        },
+        "europe-west4": {
+            "Location": "Netherlands",
+            "On Demand (USD)": 1.6500,
+            "1-year Commitment (USD)": 1.0395,
+            "3-year Commitment (USD)": 0.7425,
+            "Spot (USD)": 0.4950
+        }
+    },
+    "TPU v2 device": {
+        "asia-east1": {
+            "Location": "Taiwan",
+            "On Demand (USD)": 1.3050,
+            "1-year Commitment (USD)": 0.8222,
+            "3-year Commitment (USD)": 0.5873,
+            "Spot (USD)": 0.3915
+        },
+        "europe-west4": {
+            "Location": "Netherlands",
+            "On Demand (USD)": 1.2375,
+            "1-year Commitment (USD)": 0.7796,
+            "3-year Commitment (USD)": 0.5569,
+            "Spot (USD)": 0.3713
+        }
+    }
+}

--- a/src/integrity_tests/test_gcp.py
+++ b/src/integrity_tests/test_gcp.py
@@ -148,6 +148,15 @@ class TestGCPCatalog:
         ]
         assert all(f",{i}," in data for i in gpus)
 
+    def test_tpu_presented(self, data: str):
+        gpus = [
+            "v2",
+            "v3",
+            "v5litepod",
+            "v5p",
+        ]
+        assert all(gpu in data for gpu in gpus)
+
     def test_both_a100_presented(self, data: str):
         assert ",A100,40.0," in data
         assert ",A100,80.0," in data


### PR DESCRIPTION
1. The TPU offering has been added **on top** of the existing implementation. Please review the changes and provide any feedback or suggestions.
2. I have introduced a new **resources** folder to the project structure. The resources folder contains a file named **tpu_pricing.json**, which includes TPU pricing information sourced from the [GCP Pricing](https://cloud.google.com/tpu/pricing)

-    **Purpose of tpu_pricing.json**
The tpu_pricing.json file serves as a fallback mechanism for fetching TPU pricing information. The pricing implementation is designed to first attempt fetching prices directly from the GCP API. If the price information is not available through the API, the implementation will then fetch the pricing details from the tpu_pricing.json file.

      Here are the TPU series with zones where pricing information is currently not available in the **GCP API**:

          v5litepod for europe-west4
          v5litepod for us-central1
          v5p spot price for us-east1
          v3 spot price for us-east1
          v5litepod for us-west1 