### PR TITLE
Add H100 GPU in GCP catalog

### DIFF
--- a/src/integrity_tests/test_gcp.py
+++ b/src/integrity_tests/test_gcp.py
@@ -140,6 +140,7 @@ class TestGCPCatalog:
 
     def test_gpu_presented(self, data: str):
         gpus = [
+            "H100",
             "A100",
             "L4",
             "T4",


### PR DESCRIPTION
This adds two instance types: a3-highgpu-8g and a3-megagpu-8g. Both on-demand and spot versions.

https://github.com/dstackai/dstack/issues/1240