### PR TITLE
Add H100 GPU in AWS catalog

### DIFF
--- a/src/gpuhunt/providers/aws.py
+++ b/src/gpuhunt/providers/aws.py
@@ -217,6 +217,7 @@ class AWSProvider(AbstractProvider):
                     "c5.",
                     "m5.",
                     "p3.",
+                    "p5.",
                     "g5.",
                     "g4dn.",
                     "p4d.",

--- a/src/integrity_tests/test_aws.py
+++ b/src/integrity_tests/test_aws.py
@@ -51,6 +51,7 @@ class TestAWSCatalog:
 
     def test_gpu_presented(self, data: str):
         gpus = [
+            "H100",
             "A100",
             "A10G",
             "T4",


### PR DESCRIPTION
This adds on-demand and spot p5.48xlarge instances. Part of https://github.com/dstackai/dstack/issues/1238