### PR TITLE
Fix filter with uppercase GPU or provider name

### DIFF
--- a/src/gpuhunt/_internal/catalog.py
+++ b/src/gpuhunt/_internal/catalog.py
@@ -115,7 +115,7 @@ class Catalog:
         if query_filter.provider is not None:
             # validate providers
             for p in query_filter.provider:
-                if p not in OFFLINE_PROVIDERS + ONLINE_PROVIDERS:
+                if p.lower() not in OFFLINE_PROVIDERS + ONLINE_PROVIDERS:
                     raise ValueError(f"Unknown provider: {p}")
         else:
             query_filter.provider = OFFLINE_PROVIDERS + list(
@@ -127,7 +127,7 @@ class Catalog:
             futures = []
 
             for provider_name in ONLINE_PROVIDERS:
-                if provider_name in query_filter.provider:
+                if provider_name in map(str.lower, query_filter.provider):
                     futures.append(
                         executor.submit(
                             self._get_online_provider_items,
@@ -137,7 +137,7 @@ class Catalog:
                     )
 
             for provider_name in OFFLINE_PROVIDERS:
-                if provider_name in query_filter.provider:
+                if provider_name in map(str.lower, query_filter.provider):
                     futures.append(
                         executor.submit(
                             self._get_offline_provider_items,

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -36,7 +36,7 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         whether the catalog item matches the filters
     """
     # Common checks
-    if q.provider is not None and i.provider.lower() not in q.provider:
+    if q.provider is not None and i.provider.lower() not in map(str.lower, q.provider):
         return False
     if not is_between(i.price, q.min_price, q.max_price):
         return False
@@ -48,7 +48,7 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
         if q.gpu_name is not None:
             if i.gpu_name is None:
                 return False
-            if i.gpu_name.lower() not in q.gpu_name:
+            if i.gpu_name.lower() not in map(str.lower, q.gpu_name):
                 return False
         return True
 
@@ -62,7 +62,7 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
     if q.gpu_name is not None:
         if i.gpu_name is None:
             return False
-        if i.gpu_name.lower() not in q.gpu_name:
+        if i.gpu_name.lower() not in map(str.lower, q.gpu_name):
             return False
     if q.min_compute_capability is not None or q.max_compute_capability is not None:
         cc = get_compute_capability(i.gpu_name)

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -101,14 +101,14 @@ class QueryFilter:
         spot: if `False`, only ondemand offers will be returned. If `True`, only spot offers will be returned
     """
 
-    provider: Optional[List[str]] = None
+    provider: Optional[List[str]] = None  # strings can have mixed case
     min_cpu: Optional[int] = None
     max_cpu: Optional[int] = None
     min_memory: Optional[float] = None
     max_memory: Optional[float] = None
     min_gpu_count: Optional[int] = None
     max_gpu_count: Optional[int] = None
-    gpu_name: Optional[List[str]] = None
+    gpu_name: Optional[List[str]] = None  # strings can have mixed case
     min_gpu_memory: Optional[float] = None
     max_gpu_memory: Optional[float] = None
     min_total_gpu_memory: Optional[float] = None
@@ -120,12 +120,6 @@ class QueryFilter:
     min_compute_capability: Optional[Tuple[int, int]] = None
     max_compute_capability: Optional[Tuple[int, int]] = None
     spot: Optional[bool] = None
-
-    def __post_init__(self):
-        if self.provider is not None:
-            self.provider = [i.lower() for i in self.provider]
-        if self.gpu_name is not None:
-            self.gpu_name = [i.lower() for i in self.gpu_name]
 
     def __repr__(self) -> str:
         """

--- a/src/gpuhunt/providers/cudo.py
+++ b/src/gpuhunt/providers/cudo.py
@@ -118,7 +118,9 @@ class CudoProvider(AbstractProvider):
                     machine_type["gpu_memory"], q.min_gpu_memory, q.max_total_gpu_memory
                 ):
                     continue
-                if q.gpu_name is not None and machine_type["gpu_name"].lower() not in q.gpu_name:
+                if q.gpu_name is not None and machine_type["gpu_name"].lower() not in map(
+                    str.lower, q.gpu_name
+                ):
                     continue
                 cc = get_compute_capability(machine_type["gpu_name"])
                 if not cc or not is_between(

--- a/src/gpuhunt/providers/tensordock.py
+++ b/src/gpuhunt/providers/tensordock.py
@@ -110,7 +110,7 @@ class TensorDockProvider(AbstractProvider):
             if not is_between(gpu_info["vram"], q.min_gpu_memory, q.max_gpu_memory):
                 continue
             gpu_name = convert_gpu_name(gpu_model)
-            if q.gpu_name is not None and gpu_name.lower() not in q.gpu_name:
+            if q.gpu_name is not None and gpu_name.lower() not in map(str.lower, q.gpu_name):
                 continue
             cc = get_compute_capability(gpu_name)
             if not cc or not is_between(cc, q.min_compute_capability, q.max_compute_capability):

--- a/src/tests/_internal/test_constraints.py
+++ b/src/tests/_internal/test_constraints.py
@@ -83,8 +83,18 @@ class TestMatches:
         assert not matches(item, QueryFilter(max_gpu_memory=20.0))
 
     def test_gpu_name(self, item: CatalogItem):
+        assert matches(item, QueryFilter(gpu_name=["a100"]))
         assert matches(item, QueryFilter(gpu_name=["A100"]))
         assert not matches(item, QueryFilter(gpu_name=["A10"]))
+
+    def test_gpu_name_with_filter_setattr(self, item: CatalogItem):
+        q = QueryFilter()
+        q.gpu_name = ["a100"]
+        assert matches(item, q)
+        q.gpu_name = ["A100"]
+        assert matches(item, q)
+        q.gpu_name = ["A10"]
+        assert not matches(item, q)
 
     def test_total_gpu_memory(self, item: CatalogItem):
         assert matches(item, QueryFilter(min_total_gpu_memory=40.0))
@@ -126,4 +136,18 @@ class TestMatches:
 
     def test_provider(self, cpu_items):
         assert matches(cpu_items[0], QueryFilter(provider=["datacrunch"]))
+        assert matches(cpu_items[0], QueryFilter(provider=["DataCrunch"]))
+        assert not matches(cpu_items[0], QueryFilter(provider=["nebius"]))
+
         assert matches(cpu_items[1], QueryFilter(provider=["nebius"]))
+        assert matches(cpu_items[1], QueryFilter(provider=["Nebius"]))
+        assert not matches(cpu_items[1], QueryFilter(provider=["datacrunch"]))
+
+    def test_provider_with_filter_setattr(self, cpu_items):
+        q = QueryFilter()
+        q.provider = ["datacrunch"]
+        assert matches(cpu_items[0], q)
+        q.provider = ["DataCrunch"]
+        assert matches(cpu_items[0], q)
+        q.provider = ["nebius"]
+        assert not matches(cpu_items[0], q)


### PR DESCRIPTION
Previously, the values in `QueryFilter.gpu_name`
and `QueryFilter.provider` were assumed to always
be lowercase. However, it was not enforced when
`QueryFilter` was constructed by setting
attributes directly, e.g.
`query_filter.gpu_name = ["A10"]`, or adding
new values to the list, e.g.
`query_filter.gpu_name.append("A10")`. This lead
to incorrect filtering.

Now `QueryFilter.gpu_name` and
`QueryFilter.provider` can have mixed-case values
and it is the responsibility of the reader to
convert them to lowercase for comparisons.

https://github.com/dstackai/dstack/issues/1352