### PR TITLE
Add public method for GPU memory approximation

### DIFF
--- a/src/gpuhunt/__init__.py
+++ b/src/gpuhunt/__init__.py
@@ -8,6 +8,7 @@ from gpuhunt._internal.constraints import (
     KNOWN_AMD_GPUS,
     KNOWN_NVIDIA_GPUS,
     KNOWN_TPUS,
+    correct_gpu_memory_gib,
     matches,
 )
 from gpuhunt._internal.default import default_catalog, query

--- a/src/gpuhunt/_internal/catalog.py
+++ b/src/gpuhunt/_internal/catalog.py
@@ -154,7 +154,7 @@ class Catalog:
             items = list(heapq.merge(*[f.result() for f in completed], key=lambda i: i.price))
         return items
 
-    def load(self, version: str = None):
+    def load(self, version: Optional[str] = None):
         """
         Fetch the catalog from the S3 bucket
 

--- a/src/tests/_internal/test_constraints.py
+++ b/src/tests/_internal/test_constraints.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from gpuhunt import CatalogItem, QueryFilter
-from gpuhunt._internal.constraints import matches
+from gpuhunt._internal.constraints import correct_gpu_memory_gib, matches
 from gpuhunt._internal.models import AcceleratorVendor
 
 
@@ -170,3 +170,17 @@ class TestMatches:
         assert matches(cpu_items[0], q)
         q.provider = ["nebius"]
         assert not matches(cpu_items[0], q)
+
+
+@pytest.mark.parametrize(
+    ("gpu_name", "memory_mib", "expected_memory_gib"),
+    [
+        ("H100NVL", 95830.0, 94),
+        ("L40S", 46068.0, 48),
+        ("A10G", 23028.0, 24),
+        ("A10", 4096.0, 4),
+        ("unknown", 8200.1, 8),
+    ],
+)
+def test_correct_gpu_memory(gpu_name: str, memory_mib: float, expected_memory_gib: int) -> None:
+    assert correct_gpu_memory_gib(gpu_name, memory_mib) == expected_memory_gib

--- a/src/tests/providers/test_vastai.py
+++ b/src/tests/providers/test_vastai.py
@@ -1,9 +1,0 @@
-from gpuhunt.providers.vastai import kilo, normalize_gpu_memory
-
-
-class TestGPU:
-    def test_normalize_known(self):
-        assert normalize_gpu_memory("A100", 78 * kilo) == 80
-
-    def test_normalize_unknown(self):
-        assert normalize_gpu_memory("X1000", 78 * kilo + 10) == 78


### PR DESCRIPTION
The `correct_gpu_memory` method is based on
vastai's `normalize_gpu_memory` but only uses the
known GPU memory if it differs from reported
memory by no more than 7%. This allows to avoid
unintended corrections for vGPUs. The method is
made public so that it can be used in `dstack`.

Part of https://github.com/dstackai/dstack/issues/1523