### PR TITLE
Remove RunPod Community Cloud offers from catalog

### DIFF
--- a/src/gpuhunt/providers/runpod.py
+++ b/src/gpuhunt/providers/runpod.py
@@ -142,9 +142,7 @@ def make_request(payload: dict):
 def get_raw_catalog(offer: dict) -> List[RawCatalogItem]:
     catalog_items = []
 
-    # Check if both community_price and secure_price are present
-    if offer["community_price"] is not None and offer["secure_price"] is not None:
-        # Handle the secure_price on demand case
+    if offer["secure_price"] is not None:
         catalog_items.append(
             RawCatalogItem(
                 instance_name=offer["id"],
@@ -160,103 +158,23 @@ def get_raw_catalog(offer: dict) -> List[RawCatalogItem]:
                 disk_size=None,
             )
         )
-        secure_spot = offer["secure_spot_price"] is not None and offer["secure_spot_price"] > 0
-        if secure_spot:
-            catalog_items.append(
-                RawCatalogItem(
-                    instance_name=offer["id"],
-                    location=offer["data_center_id"],
-                    price=float(offer["secure_spot_price"] * offer["gpu"]),
-                    cpu=offer["cpu"],
-                    memory=offer["memory"],
-                    gpu_vendor=offer["gpu_vendor"],
-                    gpu_count=offer["gpu"],
-                    gpu_name=offer["gpu_name"],
-                    gpu_memory=offer["gpu_memory"],
-                    spot=True,
-                    disk_size=None,
-                )
+    if (offer["secure_spot_price"] or 0) > 0:
+        catalog_items.append(
+            RawCatalogItem(
+                instance_name=offer["id"],
+                location=offer["data_center_id"],
+                price=float(offer["secure_spot_price"] * offer["gpu"]),
+                cpu=offer["cpu"],
+                memory=offer["memory"],
+                gpu_vendor=offer["gpu_vendor"],
+                gpu_count=offer["gpu"],
+                gpu_name=offer["gpu_name"],
+                gpu_memory=offer["gpu_memory"],
+                spot=True,
+                disk_size=None,
             )
+        )
 
-        # Handle the community_price case
-        catalog_items.append(
-            RawCatalogItem(
-                instance_name=offer["id"],
-                location=offer["data_center_id"],
-                price=float(offer["community_price"] * offer["gpu"]),
-                cpu=offer["cpu"],
-                memory=offer["memory"],
-                gpu_vendor=offer["gpu_vendor"],
-                gpu_count=offer["gpu"],
-                gpu_name=offer["gpu_name"],
-                gpu_memory=offer["gpu_memory"],
-                spot=False,
-                disk_size=None,
-            )
-        )
-        community_spot = (
-            offer["community_spot_price"] is not None and offer["community_spot_price"] > 0
-        )
-        if community_spot:
-            catalog_items.append(
-                RawCatalogItem(
-                    instance_name=f'{offer["id"]}',
-                    location=offer["data_center_id"],
-                    price=float(offer["community_spot_price"] * offer["gpu"]),
-                    cpu=offer["cpu"],
-                    memory=offer["memory"],
-                    gpu_vendor=offer["gpu_vendor"],
-                    gpu_count=offer["gpu"],
-                    gpu_name=offer["gpu_name"],
-                    gpu_memory=offer["gpu_memory"],
-                    spot=True,
-                    disk_size=None,
-                )
-            )
-    else:
-        # Handle the case where only one price is present
-        price = (
-            offer["secure_price"]
-            if offer["secure_price"] is not None
-            else offer["community_price"]
-        )
-        spot_price = (
-            offer["secure_spot_price"]
-            if offer["secure_price"] is not None
-            else offer["community_spot_price"]
-        )
-        catalog_items.append(
-            RawCatalogItem(
-                instance_name=offer["id"],
-                location=offer["data_center_id"],
-                price=float(price * offer["gpu"]),
-                cpu=offer["cpu"],
-                memory=offer["memory"],
-                gpu_vendor=offer["gpu_vendor"],
-                gpu_count=offer["gpu"],
-                gpu_name=offer["gpu_name"],
-                gpu_memory=offer["gpu_memory"],
-                spot=False,
-                disk_size=None,
-            )
-        )
-        spot = spot_price is not None and spot_price > 0
-        if spot:
-            catalog_items.append(
-                RawCatalogItem(
-                    instance_name=f'{offer["id"]}',
-                    location=offer["data_center_id"],
-                    price=float(spot_price * offer["gpu"]),
-                    cpu=offer["cpu"],
-                    memory=offer["memory"],
-                    gpu_vendor=offer["gpu_vendor"],
-                    gpu_count=offer["gpu"],
-                    gpu_name=offer["gpu_name"],
-                    gpu_memory=offer["gpu_memory"],
-                    spot=True,
-                    disk_size=None,
-                )
-            )
     return catalog_items
 
 


### PR DESCRIPTION
Currently, `dstack` can only provision Secure
Cloud offers, so it's safe to remove Community
Cloud.

Fixes https://github.com/dstackai/dstack/issues/1886