### PR TITLE
Support Python 3.13, drop Python 3.8

### DIFF
--- a/.github/workflows/catalogs.yml
+++ b/.github/workflows/catalogs.yml
@@ -13,6 +13,7 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_DEFAULT_TIMEOUT: 10
   PIP_PROGRESS_BAR: off
+  PYTHON_VERSION: 3.13
 
 jobs:
   catalog-aws:
@@ -22,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -52,7 +53,7 @@ jobs:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -75,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -96,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -128,7 +129,7 @@ jobs:
           create_credentials_file: true
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -154,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -177,7 +178,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -204,7 +205,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U
@@ -234,7 +235,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           pip install pip -U

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
       - run: python -m pip install pre-commit
       - run: pre-commit run -a --show-diff-on-failure
 
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -50,10 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Install dependencies
         run: |
           pip install pip -U

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
       - run: python -m pip install pre-commit
       - run: pre-commit run -a --show-diff-on-failure
 
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ version = {attr = "gpuhunt.version.__version__"}
 line-length = 99
 
 [tool.ruff.lint]
-select = ['E', 'F', 'I' ,'Q', 'W', 'PGH', 'FLY', 'S113']
+select = ['E', 'F', 'I' ,'Q', 'W', 'UP', 'PGH', 'FLY', 'S113']
 ignore = [
   'E501',
   'E712',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A catalog of GPU pricing for different cloud providers"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",

--- a/src/gpuhunt/__init__.py
+++ b/src/gpuhunt/__init__.py
@@ -1,6 +1,5 @@
 # ruff: noqa: F401
 import warnings
-from typing import List, Type
 
 from gpuhunt._internal.catalog import Catalog
 from gpuhunt._internal.constraints import (
@@ -24,8 +23,8 @@ from gpuhunt._internal.models import (
 )
 
 # Deprecated aliases
-GPUInfo: Type[NvidiaGPUInfo]
-KNOWN_GPUS: List[NvidiaGPUInfo]
+GPUInfo: type[NvidiaGPUInfo]
+KNOWN_GPUS: list[NvidiaGPUInfo]
 
 
 def _warn_renamed(old: str, new: str) -> None:

--- a/src/gpuhunt/_internal/catalog.py
+++ b/src/gpuhunt/_internal/catalog.py
@@ -6,8 +6,9 @@ import logging
 import time
 import urllib.request
 import zipfile
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, wait
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import gpuhunt._internal.constraints as constraints
 from gpuhunt._internal.models import AcceleratorVendor, CatalogItem, QueryFilter
@@ -31,14 +32,14 @@ class Catalog:
         """
         self.catalog = None
         self.loaded_at = None
-        self.providers: List[AbstractProvider] = []
+        self.providers: list[AbstractProvider] = []
         self.balance_resources = balance_resources
         self.auto_reload = auto_reload
 
     def query(
         self,
         *,
-        provider: Optional[Union[str, List[str]]] = None,
+        provider: Optional[Union[str, list[str]]] = None,
         min_cpu: Optional[int] = None,
         max_cpu: Optional[int] = None,
         min_memory: Optional[float] = None,
@@ -46,7 +47,7 @@ class Catalog:
         min_gpu_count: Optional[int] = None,
         max_gpu_count: Optional[int] = None,
         gpu_vendor: Optional[Union[AcceleratorVendor, str]] = None,
-        gpu_name: Optional[Union[str, List[str]]] = None,
+        gpu_name: Optional[Union[str, list[str]]] = None,
         min_gpu_memory: Optional[float] = None,
         max_gpu_memory: Optional[float] = None,
         min_total_gpu_memory: Optional[float] = None,
@@ -55,10 +56,10 @@ class Catalog:
         max_disk_size: Optional[int] = None,
         min_price: Optional[float] = None,
         max_price: Optional[float] = None,
-        min_compute_capability: Optional[Union[str, Tuple[int, int]]] = None,
-        max_compute_capability: Optional[Union[str, Tuple[int, int]]] = None,
+        min_compute_capability: Optional[Union[str, tuple[int, int]]] = None,
+        max_compute_capability: Optional[Union[str, tuple[int, int]]] = None,
         spot: Optional[bool] = None,
-    ) -> List[CatalogItem]:
+    ) -> list[CatalogItem]:
         """
         Query the catalog for matching offers
 
@@ -187,7 +188,7 @@ class Catalog:
 
     def _get_offline_provider_items(
         self, provider_name: str, query_filter: QueryFilter
-    ) -> List[CatalogItem]:
+    ) -> list[CatalogItem]:
         logger.debug("Loading items for offline provider %s", provider_name)
 
         items = []
@@ -209,7 +210,7 @@ class Catalog:
 
     def _get_online_provider_items(
         self, provider_name: str, query_filter: QueryFilter
-    ) -> List[CatalogItem]:
+    ) -> list[CatalogItem]:
         logger.debug("Loading items for online provider %s", provider_name)
         items = []
         found = False

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 from gpuhunt._internal.models import (
     AcceleratorVendor,
@@ -23,7 +23,7 @@ def _is_tpu(name: str) -> bool:
     return False
 
 
-Comparable = TypeVar("Comparable", bound=Union[int, float, Tuple[int, int]])
+Comparable = TypeVar("Comparable", bound=Union[int, float, tuple[int, int]])
 
 
 def is_between(value: Comparable, left: Optional[Comparable], right: Optional[Comparable]) -> bool:
@@ -108,7 +108,7 @@ def matches(i: CatalogItem, q: QueryFilter) -> bool:
     return True
 
 
-def get_compute_capability(gpu_name: str) -> Optional[Tuple[int, int]]:
+def get_compute_capability(gpu_name: str) -> Optional[tuple[int, int]]:
     for gpu in KNOWN_NVIDIA_GPUS:
         if gpu.name.lower() == gpu_name.lower():
             return gpu.compute_capability
@@ -136,7 +136,7 @@ def correct_gpu_memory_gib(gpu_name: str, memory_mib: float) -> int:
     return round(memory_gib)
 
 
-KNOWN_NVIDIA_GPUS: List[NvidiaGPUInfo] = [
+KNOWN_NVIDIA_GPUS: list[NvidiaGPUInfo] = [
     NvidiaGPUInfo(name="A10", memory=24, compute_capability=(8, 6)),
     NvidiaGPUInfo(name="A40", memory=48, compute_capability=(8, 6)),
     NvidiaGPUInfo(name="A100", memory=40, compute_capability=(8, 0)),
@@ -169,7 +169,7 @@ KNOWN_NVIDIA_GPUS: List[NvidiaGPUInfo] = [
     NvidiaGPUInfo(name="V100", memory=32, compute_capability=(7, 0)),
 ]
 
-KNOWN_AMD_GPUS: List[AMDGPUInfo] = [
+KNOWN_AMD_GPUS: list[AMDGPUInfo] = [
     AMDGPUInfo(name="MI100", memory=32, architecture=AMDArchitecture.CDNA),
     AMDGPUInfo(name="MI210", memory=64, architecture=AMDArchitecture.CDNA2),
     AMDGPUInfo(name="MI250", memory=128, architecture=AMDArchitecture.CDNA2),
@@ -180,8 +180,8 @@ KNOWN_AMD_GPUS: List[AMDGPUInfo] = [
     AMDGPUInfo(name="MI325X", memory=288, architecture=AMDArchitecture.CDNA3),
 ]
 
-KNOWN_TPUS: List[TPUInfo] = [TPUInfo(name=version, memory=0) for version in _TPU_VERSIONS]
+KNOWN_TPUS: list[TPUInfo] = [TPUInfo(name=version, memory=0) for version in _TPU_VERSIONS]
 
-KNOWN_ACCELERATORS: List[Union[NvidiaGPUInfo, AMDGPUInfo, TPUInfo]] = (
+KNOWN_ACCELERATORS: list[Union[NvidiaGPUInfo, AMDGPUInfo, TPUInfo]] = (
     KNOWN_NVIDIA_GPUS + KNOWN_AMD_GPUS + KNOWN_TPUS
 )

--- a/src/gpuhunt/_internal/default.py
+++ b/src/gpuhunt/_internal/default.py
@@ -10,7 +10,7 @@ from gpuhunt._internal.catalog import Catalog
 logger = logging.getLogger(__name__)
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def default_catalog() -> Catalog:
     """
     Returns:

--- a/src/gpuhunt/_internal/models.py
+++ b/src/gpuhunt/_internal/models.py
@@ -2,10 +2,7 @@ import enum
 from dataclasses import asdict, dataclass, fields
 from typing import (
     ClassVar,
-    Dict,
-    List,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -91,7 +88,7 @@ class RawCatalogItem:
             disk_size=empty_as_none(v.get("disk_size"), loader=float),
         )
 
-    def dict(self) -> Dict[str, Union[str, int, float, bool, None]]:
+    def dict(self) -> dict[str, Union[str, int, float, bool, None]]:
         return asdict(self)
 
 
@@ -171,7 +168,7 @@ class QueryFilter:
         spot: if `False`, only ondemand offers will be returned. If `True`, only spot offers will be returned
     """
 
-    provider: Optional[List[str]] = None  # strings can have mixed case
+    provider: Optional[list[str]] = None  # strings can have mixed case
     min_cpu: Optional[int] = None
     max_cpu: Optional[int] = None
     min_memory: Optional[float] = None
@@ -179,7 +176,7 @@ class QueryFilter:
     min_gpu_count: Optional[int] = None
     max_gpu_count: Optional[int] = None
     gpu_vendor: Optional[AcceleratorVendor] = None
-    gpu_name: Optional[List[str]] = None  # strings can have mixed case
+    gpu_name: Optional[list[str]] = None  # strings can have mixed case
     min_gpu_memory: Optional[float] = None
     max_gpu_memory: Optional[float] = None
     min_total_gpu_memory: Optional[float] = None
@@ -188,8 +185,8 @@ class QueryFilter:
     max_disk_size: Optional[int] = None
     min_price: Optional[float] = None
     max_price: Optional[float] = None
-    min_compute_capability: Optional[Tuple[int, int]] = None
-    max_compute_capability: Optional[Tuple[int, int]] = None
+    min_compute_capability: Optional[tuple[int, int]] = None
+    max_compute_capability: Optional[tuple[int, int]] = None
     spot: Optional[bool] = None
 
     def __repr__(self) -> str:
@@ -219,7 +216,7 @@ class AcceleratorInfo:
 @dataclass
 class NvidiaGPUInfo(AcceleratorInfo):
     vendor = AcceleratorVendor.NVIDIA
-    compute_capability: Tuple[int, int]
+    compute_capability: tuple[int, int]
 
 
 @dataclass

--- a/src/gpuhunt/_internal/storage.py
+++ b/src/gpuhunt/_internal/storage.py
@@ -1,13 +1,14 @@
 import csv
 import dataclasses
-from typing import Iterable, List, Type, TypeVar
+from collections.abc import Iterable
+from typing import TypeVar
 
 from gpuhunt._internal.models import RawCatalogItem
 
 T = TypeVar("T", bound=RawCatalogItem)
 
 
-def dump(items: List[T], path: str, *, cls: Type[T] = RawCatalogItem):
+def dump(items: list[T], path: str, *, cls: type[T] = RawCatalogItem):
     with open(path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=[field.name for field in dataclasses.fields(cls)])
         writer.writeheader()
@@ -15,9 +16,9 @@ def dump(items: List[T], path: str, *, cls: Type[T] = RawCatalogItem):
             writer.writerow(item.dict())
 
 
-def load(path: str, *, cls: Type[T] = RawCatalogItem) -> List[T]:
+def load(path: str, *, cls: type[T] = RawCatalogItem) -> list[T]:
     items = []
-    with open(path, "r", newline="") as f:
+    with open(path, newline="") as f:
         reader: Iterable[dict[str, str]] = csv.DictReader(f)
         for row in reader:
             item = cls.from_dict(row)

--- a/src/gpuhunt/_internal/utils.py
+++ b/src/gpuhunt/_internal/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 
 def empty_as_none(value: Optional[str], loader: Optional[Callable] = None):
@@ -10,8 +10,8 @@ def empty_as_none(value: Optional[str], loader: Optional[Callable] = None):
 
 
 def parse_compute_capability(
-    value: Optional[Union[str, Tuple[int, int]]],
-) -> Optional[Tuple[int, int]]:
+    value: Optional[Union[str, tuple[int, int]]],
+) -> Optional[tuple[int, int]]:
     if isinstance(value, str):
         major, minor = value.split(".")
         return int(major), int(minor)

--- a/src/gpuhunt/providers/__init__.py
+++ b/src/gpuhunt/providers/__init__.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Optional
 
 from gpuhunt._internal.models import QueryFilter, RawCatalogItem
 
@@ -10,9 +10,9 @@ class AbstractProvider(ABC):
     @abstractmethod
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         pass
 
     @classmethod
-    def filter(cls, offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
+    def filter(cls, offers: list[RawCatalogItem]) -> list[RawCatalogItem]:
         return offers

--- a/src/gpuhunt/providers/cudo.py
+++ b/src/gpuhunt/providers/cudo.py
@@ -3,7 +3,7 @@ import math
 from collections import namedtuple
 from itertools import chain
 from math import ceil
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 import requests
 
@@ -29,14 +29,14 @@ class CudoProvider(AbstractProvider):
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         offers = self.fetch_offers(query_filter, balance_resources)
         offers = get_min_price_for_location_and_instance(offers)
         return sorted(offers, key=lambda i: i.price)
 
     def fetch_offers(
         self, query_filter: Optional[QueryFilter], balance_resources
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         machine_types = self.list_vm_machine_types()
         if query_filter is not None:
             return self.optimize_offers(machine_types, query_filter, balance_resources)
@@ -59,7 +59,7 @@ class CudoProvider(AbstractProvider):
             return list(chain.from_iterable(offers))
 
     @staticmethod
-    def list_vm_machine_types() -> Dict:
+    def list_vm_machine_types() -> dict:
         resp = requests.request(
             method="GET",
             url=f"{API_URL}/vms/machine-types-2",
@@ -71,7 +71,7 @@ class CudoProvider(AbstractProvider):
         resp.raise_for_status()
 
     @staticmethod
-    def optimize_offers(machine_types, q: QueryFilter, balance_resource) -> List[RawCatalogItem]:
+    def optimize_offers(machine_types, q: QueryFilter, balance_resource) -> list[RawCatalogItem]:
         offers = []
 
         # Empty query, example: QureyFilter(provider="cudo")
@@ -180,7 +180,7 @@ def get_raw_catalog(machine_type, spec):
     return raw
 
 
-def get_min_price_for_location_and_instance(offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
+def get_min_price_for_location_and_instance(offers: list[RawCatalogItem]) -> list[RawCatalogItem]:
     """
     Returns offers with the minimum price for each unique combination
     of location and instance name.

--- a/src/gpuhunt/providers/datacrunch.py
+++ b/src/gpuhunt/providers/datacrunch.py
@@ -1,7 +1,8 @@
 import copy
 import itertools
 import logging
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Optional
 
 from datacrunch import DataCrunchClient
 from datacrunch.instance_types.instance_types import InstanceType
@@ -25,7 +26,7 @@ class DataCrunchProvider(AbstractProvider):
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         instance_types = self._get_instance_types()
         locations = self._get_locations()
 
@@ -35,23 +36,23 @@ class DataCrunchProvider(AbstractProvider):
 
         return sorted(instances, key=lambda x: x.price)
 
-    def _get_instance_types(self) -> List[InstanceType]:
+    def _get_instance_types(self) -> list[InstanceType]:
         return self.datacrunch_client.instance_types.get()
 
-    def _get_availabilities(self, spot: bool) -> List[dict]:
+    def _get_availabilities(self, spot: bool) -> list[dict]:
         return self.datacrunch_client.instances.get_availabilities(is_spot=spot)
 
-    def _get_locations(self) -> List[dict]:
+    def _get_locations(self) -> list[dict]:
         return self.datacrunch_client.locations.get()
 
     @classmethod
-    def filter(cls, offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
+    def filter(cls, offers: list[RawCatalogItem]) -> list[RawCatalogItem]:
         return [o for o in offers if o.gpu_name not in ALL_AMD_GPUS]  # skip AMD GPU
 
 
 def generate_instances(
     spots: Iterable[bool], location_codes: Iterable[str], instance_types: Iterable[InstanceType]
-) -> List[RawCatalogItem]:
+) -> list[RawCatalogItem]:
     instances = []
     for spot, location, instance in itertools.product(spots, location_codes, instance_types):
         item = transform_instance(copy.copy(instance), spot, location)

--- a/src/gpuhunt/providers/lambdalabs.py
+++ b/src/gpuhunt/providers/lambdalabs.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import re
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import requests
 
@@ -36,7 +36,7 @@ class LambdaLabsProvider(AbstractProvider):
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         offers = []
         data = requests.get(
             instance_types_url, headers={"Authorization": f"Bearer {self.token}"}, timeout=10
@@ -67,7 +67,7 @@ class LambdaLabsProvider(AbstractProvider):
         offers = self.add_regions(offers)
         return sorted(offers, key=lambda i: i.price)
 
-    def add_regions(self, offers: List[RawCatalogItem]) -> List[RawCatalogItem]:
+    def add_regions(self, offers: list[RawCatalogItem]) -> list[RawCatalogItem]:
         # TODO: we don't know which regions are actually available for each instance type
         region_offers = []
         for region in all_regions:
@@ -78,7 +78,7 @@ class LambdaLabsProvider(AbstractProvider):
         return region_offers
 
 
-def parse_description(v: str) -> Optional[Tuple[int, str, float]]:
+def parse_description(v: str) -> Optional[tuple[int, str, float]]:
     """Returns gpus count, gpu name, and GPU memory"""
     r = re.match(r"^(\d)x (?:Tesla )?(.+) \((\d+) GB", v)
     if r is None:

--- a/src/gpuhunt/providers/nebius.py
+++ b/src/gpuhunt/providers/nebius.py
@@ -3,7 +3,7 @@ import logging
 import re
 import time
 from collections import defaultdict
-from typing import Dict, List, Literal, Optional, TypedDict
+from typing import Literal, Optional, TypedDict
 
 import bs4
 import jwt
@@ -100,7 +100,7 @@ class NebiusProvider(AbstractProvider):
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         zone = self.api_client.compute_zones_list()[0]["id"]
         skus = []
         page_token = None
@@ -121,7 +121,7 @@ class NebiusProvider(AbstractProvider):
     @staticmethod
     def get_gpu_platforms(
         zone: str, platform_resources: "PlatformResourcePrice"
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         items = []
         for platform, presets in GPU_PLATFORMS.items():
             prices = platform_resources[platform]
@@ -153,7 +153,7 @@ class NebiusProvider(AbstractProvider):
     @staticmethod
     def get_cpu_platforms(
         zone: str, platform_resources: "PlatformResourcePrice"
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         items = []
         for platform, limits in CPU_PLATFORMS.items():
             prices = platform_resources[platform]
@@ -179,7 +179,7 @@ class NebiusProvider(AbstractProvider):
         return items
 
     @staticmethod
-    def parse_gpu_platforms(raw_html: str) -> Dict[str, List[List]]:
+    def parse_gpu_platforms(raw_html: str) -> dict[str, list[list]]:
         """Parse GPU platforms from Nebius docs.
 
         Returns:
@@ -209,7 +209,7 @@ class NebiusProvider(AbstractProvider):
         return platforms
 
     @staticmethod
-    def parse_cpu_platforms(raw_html: str) -> Dict[str, Dict[str, List]]:
+    def parse_cpu_platforms(raw_html: str) -> dict[str, dict[str, list]]:
         """Parse CPU platforms from Nebius docs.
 
         Returns:
@@ -238,7 +238,7 @@ class NebiusProvider(AbstractProvider):
             }
         return platforms
 
-    def aggregate_skus(self, skus: List[dict]) -> "PlatformResourcePrice":
+    def aggregate_skus(self, skus: list[dict]) -> "PlatformResourcePrice":
         vm_resources = {
             "GPU": "gpu",
             "RAM": "ram",
@@ -265,7 +265,7 @@ class NebiusProvider(AbstractProvider):
         return platform_resources
 
     @staticmethod
-    def get_sku_price(pricing_versions: List[dict]) -> Optional[float]:
+    def get_sku_price(pricing_versions: list[dict]) -> Optional[float]:
         now = datetime.datetime.now(datetime.timezone.utc)
         price = None
         for version in sorted(pricing_versions, key=lambda p: p["effectiveTime"]):
@@ -331,7 +331,7 @@ class NebiusAPIClient:
         resp.raise_for_status()
         return resp.json()
 
-    def compute_zones_list(self) -> List[dict]:
+    def compute_zones_list(self) -> list[dict]:
         logger.debug("Fetching compute zones")
         self.get_token()
         resp = self._s.get(self.url("compute", "/zones"))
@@ -352,8 +352,8 @@ class ServiceAccount(TypedDict):
 
 
 class BillingSkusListResponse(TypedDict):
-    skus: List[dict]
+    skus: list[dict]
     nextPageToken: Optional[str]
 
 
-PlatformResourcePrice = Dict[str, Dict[Literal["cpu", "ram", "gpu"], float]]
+PlatformResourcePrice = dict[str, dict[Literal["cpu", "ram", "gpu"], float]]

--- a/src/gpuhunt/providers/tensordock.py
+++ b/src/gpuhunt/providers/tensordock.py
@@ -1,6 +1,6 @@
 import logging
 from math import ceil
-from typing import List, Optional, TypeVar, Union
+from typing import Optional, TypeVar, Union
 
 import requests
 
@@ -42,7 +42,7 @@ class TensorDockProvider(AbstractProvider):
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         logger.info("Fetching TensorDock offers")
 
         hostnodes = requests.get(marketplace_hostnodes_url, timeout=10).json()["hostnodes"]
@@ -93,7 +93,7 @@ class TensorDockProvider(AbstractProvider):
         instance_name: str,
         location: str,
         balance_resources: bool = True,
-    ) -> List[RawCatalogItem]:
+    ) -> list[RawCatalogItem]:
         """
         Picks the best offer for the given query filter
         Doesn't respect max values, additional filtering is required

--- a/src/gpuhunt/providers/vastai.py
+++ b/src/gpuhunt/providers/vastai.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Literal, Optional, Union
 
 import requests
 
@@ -19,13 +19,13 @@ FilterValue = Union[int, float, str, bool]
 class VastAIProvider(AbstractProvider):
     NAME = "vastai"
 
-    def __init__(self, extra_filters: Optional[Dict[str, Dict[Operators, FilterValue]]] = None):
+    def __init__(self, extra_filters: Optional[dict[str, dict[Operators, FilterValue]]] = None):
         self.extra_filters = extra_filters
 
     def get(
         self, query_filter: Optional[QueryFilter] = None, balance_resources: bool = True
-    ) -> List[RawCatalogItem]:
-        filters: Dict[str, Any] = self.make_filters(query_filter or QueryFilter())
+    ) -> list[RawCatalogItem]:
+        filters: dict[str, Any] = self.make_filters(query_filter or QueryFilter())
         if self.extra_filters:
             for key, constraints in self.extra_filters.items():
                 for op, value in constraints.items():
@@ -79,7 +79,7 @@ class VastAIProvider(AbstractProvider):
         return instance_offers
 
     @staticmethod
-    def make_filters(q: QueryFilter) -> Dict[str, Dict[Operators, FilterValue]]:
+    def make_filters(q: QueryFilter) -> dict[str, dict[Operators, FilterValue]]:
         filters = defaultdict(dict)
         if q.min_cpu is not None:
             filters["cpu_cores"]["gte"] = q.min_cpu
@@ -110,7 +110,7 @@ class VastAIProvider(AbstractProvider):
         return filters
 
     @staticmethod
-    def satisfies_filters(offer: dict, filters: Dict[str, Dict[Operators, FilterValue]]) -> bool:
+    def satisfies_filters(offer: dict, filters: dict[str, dict[Operators, FilterValue]]) -> bool:
         for key in filters:
             if key not in offer:
                 continue
@@ -148,7 +148,7 @@ def get_location(location: Optional[str]) -> str:
     return location.lower().replace(" ", "")
 
 
-def compute_cap(cc: Tuple[int, int]) -> str:
+def compute_cap(cc: tuple[int, int]) -> str:
     """
     >>> compute_cap((7, 0))
     '700'

--- a/src/integrity_tests/test_azure.py
+++ b/src/integrity_tests/test_azure.py
@@ -1,18 +1,17 @@
 import csv
 from pathlib import Path
-from typing import List
 
 import pytest
 
 
 @pytest.fixture
-def data_rows(catalog_dir: Path) -> List[dict]:
-    with open(catalog_dir / "azure.csv", "r") as f:
+def data_rows(catalog_dir: Path) -> list[dict]:
+    with open(catalog_dir / "azure.csv") as f:
         return list(csv.DictReader(f))
 
 
 class TestAzureCatalog:
-    def test_standard_d2s_v3_locations(self, data_rows: List[dict]):
+    def test_standard_d2s_v3_locations(self, data_rows: list[dict]):
         expected_locations = {
             "attatlanta1",
             "attdallas1",
@@ -82,13 +81,13 @@ class TestAzureCatalog:
         )
         assert expected_locations == locations
 
-    def test_spots_presented(self, data_rows: List[dict]):
+    def test_spots_presented(self, data_rows: list[dict]):
         assert any(row["spot"] == "True" for row in data_rows)
 
-    def test_ondemand_presented(self, data_rows: List[dict]):
+    def test_ondemand_presented(self, data_rows: list[dict]):
         assert any(row["spot"] == "False" for row in data_rows)
 
-    def test_gpu_presented(self, data_rows: List[dict]):
+    def test_gpu_presented(self, data_rows: list[dict]):
         expected_gpus = {
             "A100",
             "A10",
@@ -98,7 +97,7 @@ class TestAzureCatalog:
         gpus = set(row["gpu_name"] for row in data_rows if row["gpu_name"])
         assert expected_gpus == gpus
 
-    def test_both_a100_presented(self, data_rows: List[dict]):
+    def test_both_a100_presented(self, data_rows: list[dict]):
         expected_gpu_memory = {"40.0", "80.0"}
         gpu_memory = set(row["gpu_memory"] for row in data_rows if row["gpu_name"] == "A100")
         assert expected_gpu_memory == gpu_memory

--- a/src/integrity_tests/test_datacrunch.py
+++ b/src/integrity_tests/test_datacrunch.py
@@ -1,7 +1,6 @@
 import csv
 from collections import Counter
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -9,13 +8,13 @@ from gpuhunt.providers.datacrunch import ALL_AMD_GPUS, GPU_MAP
 
 
 @pytest.fixture
-def data_rows(catalog_dir: Path) -> List[dict]:
+def data_rows(catalog_dir: Path) -> list[dict]:
     file = catalog_dir / "datacrunch.csv"
     reader = csv.DictReader(file.open())
     return list(reader)
 
 
-def select_row(rows, name: str) -> List[str]:
+def select_row(rows, name: str) -> list[str]:
     return [r[name] for r in rows if r[name]]
 
 

--- a/src/integrity_tests/test_oci.py
+++ b/src/integrity_tests/test_oci.py
@@ -1,32 +1,31 @@
 import csv
 from operator import itemgetter
 from pathlib import Path
-from typing import List
 
 import pytest
 
 
 @pytest.fixture
-def data_rows(catalog_dir: Path) -> List[dict]:
+def data_rows(catalog_dir: Path) -> list[dict]:
     with open(catalog_dir / "oci.csv") as f:
         return list(csv.DictReader(f))
 
 
 @pytest.mark.parametrize("gpu", ["P100", "V100", "A10", "A100", "H100", ""])
-def test_gpu_present(gpu: str, data_rows: List[dict]):
+def test_gpu_present(gpu: str, data_rows: list[dict]):
     assert gpu in map(itemgetter("gpu_name"), data_rows)
 
 
-def test_on_demand_present(data_rows: List[dict]):
+def test_on_demand_present(data_rows: list[dict]):
     assert "False" in map(itemgetter("spot"), data_rows)
 
 
 @pytest.mark.parametrize("prefix", ["VM.Standard", "BM.Standard", "VM.GPU", "BM.GPU"])
-def test_family_present(prefix: str, data_rows: List[dict]):
+def test_family_present(prefix: str, data_rows: list[dict]):
     assert any(name.startswith(prefix) for name in map(itemgetter("instance_name"), data_rows))
 
 
-def test_quantity_decreases_as_query_complexity_increases(data_rows: List[dict]):
+def test_quantity_decreases_as_query_complexity_increases(data_rows: list[dict]):
     zero_or_one_gpu = list(filter(lambda row: int(row["gpu_count"]) in (0, 1), data_rows))
     zero_gpu = list(filter(lambda row: int(row["gpu_count"]) == 0, data_rows))
     one_gpu = list(filter(lambda row: int(row["gpu_count"]) == 1, data_rows))

--- a/src/integrity_tests/test_runpod.py
+++ b/src/integrity_tests/test_runpod.py
@@ -1,7 +1,6 @@
 import csv
 from collections import Counter
 from pathlib import Path
-from typing import List
 
 import pytest
 
@@ -9,13 +8,13 @@ from gpuhunt.providers.runpod import GPU_MAP
 
 
 @pytest.fixture
-def data_rows(catalog_dir: Path) -> List[dict]:
+def data_rows(catalog_dir: Path) -> list[dict]:
     file = catalog_dir / "runpod.csv"
     reader = csv.DictReader(file.open())
     return list(reader)
 
 
-def select_row(rows, name: str) -> List[str]:
+def select_row(rows, name: str) -> list[str]:
     return [r[name] for r in rows if r[name]]
 
 

--- a/src/tests/_internal/test_constraints.py
+++ b/src/tests/_internal/test_constraints.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from gpuhunt import CatalogItem, QueryFilter
@@ -26,7 +24,7 @@ def item() -> CatalogItem:
 
 
 @pytest.fixture
-def cpu_items() -> List[CatalogItem]:
+def cpu_items() -> list[CatalogItem]:
     datacrunch = CatalogItem(
         instance_name="CPU.120V.480G",
         location="ICE-01",

--- a/src/tests/providers/test_cudo.py
+++ b/src/tests/providers/test_cudo.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 import gpuhunt._internal.catalog as internal_catalog
@@ -14,7 +12,7 @@ from gpuhunt.providers.cudo import (
 
 
 @pytest.fixture
-def machine_types() -> List[dict]:
+def machine_types() -> list[dict]:
     return [
         {
             "dataCenterId": "br-saopaulo-1",

--- a/src/tests/providers/test_datacrunch.py
+++ b/src/tests/providers/test_datacrunch.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import List
 
 import pytest
 
@@ -15,7 +14,7 @@ from gpuhunt.providers.datacrunch import (
 
 
 @pytest.fixture
-def raw_instance_types() -> List[dict]:
+def raw_instance_types() -> list[dict]:
     # datacrunch.instance_types.get()
     one_gpu = {
         "best_for": [
@@ -103,7 +102,7 @@ def raw_instance_types() -> List[dict]:
 
 
 @pytest.fixture
-def availabilities() -> List[dict]:
+def availabilities() -> list[dict]:
     # datacrunch.instances.get_availabilities(is_spot=True)
     data = [
         {
@@ -183,7 +182,7 @@ def test_gpu_name(caplog):
     assert get_gpu_name("") is None
 
 
-def transform(raw_catalog_items: List[RawCatalogItem]) -> List[CatalogItem]:
+def transform(raw_catalog_items: list[RawCatalogItem]) -> list[CatalogItem]:
     items = []
     for raw in raw_catalog_items:
         item = CatalogItem(provider="datacrunch", **dataclasses.asdict(raw))

--- a/src/tests/providers/test_providers.py
+++ b/src/tests/providers/test_providers.py
@@ -20,6 +20,8 @@ def providers():
         for _, member in inspect.getmembers(module):
             if not inspect.isclass(member):
                 continue
+            if member.__name__.islower():
+                continue  # skip builtins to avoid CPython bug #89489 in `issubclass` below
             if not issubclass(member, gpuhunt.providers.AbstractProvider):
                 continue
             if member.__name__ == "AbstractProvider":
@@ -27,6 +29,7 @@ def providers():
             if member.NAME == "nebius":  # The provider has been temporarily disabled
                 continue
             members.append(member)
+    assert members
     return members
 
 

--- a/src/tests/providers/test_tensordock.py
+++ b/src/tests/providers/test_tensordock.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from gpuhunt import QueryFilter
@@ -88,7 +86,7 @@ class TestTensorDockMinimalConfiguration:
 
 def make_offers(
     specs: dict, cpu: int, memory: float, disk_size: float, gpu_count: int
-) -> List[RawCatalogItem]:
+) -> list[RawCatalogItem]:
     gpu = list(specs["gpu"].values())[0]
     price = cpu * specs["cpu"]["price"]
     price += memory * specs["ram"]["price"]


### PR DESCRIPTION
- Update supported Python versions
- Enable pyupgrade rules and upgrade the codebase to Python 3.9
  Most changes were done automatically with `ruff check --fix --unsafe-fixes`
- Fix tests after codebase upgrade

Part of https://github.com/dstackai/dstack/issues/1833
Consider reviewing per commit