### PR TITLE
Fix Runpod Secure Cloud API

### DIFF
--- a/src/gpuhunt/providers/runpod.py
+++ b/src/gpuhunt/providers/runpod.py
@@ -75,7 +75,7 @@ def build_query_variables(gpu_types: list[dict]) -> list[dict]:
                     "minDisk": None,
                     "minMemoryInGb": None,
                     "minVcpuCount": None,
-                    "secureCloud": None,
+                    "secureCloud": True,
                 }
             )
 


### PR DESCRIPTION
Issue: 
Runpod's API did not return Mi300x although it was available on Runpod's web console.

Solution:
Before the API would return Mi300x instances in secure cloud with `"secureCloud": null `in the API. Now Mi300x instances of secure cloud is only returned with `"secureCloud": true`. 

Also, we were only using secure cloud instances, therefore "secureCloud": true will not have effect on our offer list.

