### PR TITLE
Fix Azure integrity tests

### DIFF
--- a/src/gpuhunt/providers/azure.py
+++ b/src/gpuhunt/providers/azure.py
@@ -114,7 +114,6 @@ class AzureProvider(AbstractProvider):
                     res = session.get(
                         prices_url,
                         params={
-                            "api-version": "2023-01-01-preview",
                             "$filter": " and ".join(prices_filters),
                             "$skip": page_id * retail_prices_page_size,
                         },

--- a/src/integrity_tests/test_azure.py
+++ b/src/integrity_tests/test_azure.py
@@ -46,6 +46,7 @@ class TestAzureCatalog:
             "jioindiawest",
             "koreacentral",
             "koreasouth",
+            "malaysiawest",
             "mexicocentral",
             "newzealandnorth",
             "northcentralus",
@@ -82,7 +83,8 @@ class TestAzureCatalog:
         locations = set(
             row["location"] for row in data_rows if row["instance_name"] == "Standard_D2s_v3"
         )
-        assert expected_locations == locations
+        missing = expected_locations - locations
+        assert not missing
 
     def test_spots_presented(self, data_rows: list[dict]):
         assert any(row["spot"] == "True" for row in data_rows)


### PR DESCRIPTION
Not sure why, but setting `api-version` to `2023-01-01-preview` leads to unstable results with a different set of locations each time. Using the default API version fixes this.