### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,42 +11,11 @@ env:
   PIP_PROGRESS_BAR: off
 
 jobs:
-  python-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-      - run: python -m pip install pre-commit
-      - run: pre-commit run -a --show-diff-on-failure
-
-  python-test:
-    needs: [python-lint]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install '.[all,dev]'
-      - name: Run doctest
-        run: |
-          pytest --doctest-modules src/gpuhunt
-      - name: Run pytest
-        run: |
-          pytest src/tests
+  quality-control:
+    uses: ./.github/workflows/test.yml
 
   pypi-upload:
-    needs: [ python-test ]
+    needs: [ quality-control ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
   workflow_dispatch:
+  workflow_call:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: on


### PR DESCRIPTION
Tests in the release workflow were failing because of a missing condition to skip the Nebius module on Python 3.9. Fixed by refactoring the release workflow to call the test workflow that has the up-to-date jobs for running tests.

Sample workflow run: https://github.com/dstackai/gpuhunt/actions/runs/14203797933