### PR TITLE
Fix a3 mega spot instances not being populated

### DIFF
--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -329,6 +329,7 @@ class Prices:
             family = {
                 "nvidia-tesla-a100-80gb": "nvidia-a100-80gb",
                 "nvidia-h100-80gb-mega": "nvidia-h100-mega-80gb",
+                "nvidia-h100-80gb-plus": "nvidia-h100-mega-80gb",
             }.get(family, family)
         else:
             r = re.match(r"^([a-z]\d.?) ", family.lower())


### PR DESCRIPTION
Sku description for spot megas is `Nvidia H100 80GB Plus GPU attached to Spot Preemptible VMs running in ____`. This adds the name mapping for it. 