### PR TITLE
Use /vms/machine-types cudo endpoint

### DIFF
--- a/src/gpuhunt/providers/cudo.py
+++ b/src/gpuhunt/providers/cudo.py
@@ -65,7 +65,7 @@ class CudoProvider(AbstractProvider):
     def list_vm_machine_types() -> dict:
         resp = requests.request(
             method="GET",
-            url=f"{API_URL}/vms/machine-types-2",
+            url=f"{API_URL}/vms/machine-types",
             timeout=10,
         )
         if resp.ok:


### PR DESCRIPTION
Cudo renamed /vms/machine-types-2 to /vms/machine-types, which they claim are functionally equivalent.