### PR TITLE
Fix Lambda integrity tests

### DIFF
--- a/src/integrity_tests/test_lambdalabs.py
+++ b/src/integrity_tests/test_lambdalabs.py
@@ -33,7 +33,6 @@ def test_locations(data_rows: list[dict]):
         "europe-central-1",
         "me-west-1",
         "us-east-1",
-        "us-east-2",
         "us-east-3",
         "us-midwest-1",
         "us-south-1",


### PR DESCRIPTION
us-east-2 is not returned in the list of images.
This may mean that the region is currently
disabled. While it is still shown in the Lambda
console, no instances are available there.