### PR TITLE
Cloudrift test fix

### DIFF
--- a/src/gpuhunt/providers/cloudrift.py
+++ b/src/gpuhunt/providers/cloudrift.py
@@ -41,7 +41,7 @@ def generate_instances(instance) -> list[RawCatalogItem]:
 
     instance_types = []
     for variant in instance["variants"]:
-        for location, _count in variant["available_nodes_per_dc"].items():
+        for location, _count in variant["nodes_per_dc"].items():
             raw = RawCatalogItem(
                 instance_name=variant["name"],
                 location=location,

--- a/src/gpuhunt/providers/cloudrift.py
+++ b/src/gpuhunt/providers/cloudrift.py
@@ -32,7 +32,9 @@ class CloudRiftProvider(AbstractProvider):
 
 def generate_instances(instance) -> list[RawCatalogItem]:
     instance_gpu_brand = instance["brand_short"]
-    dstack_gpu_name = GPU_MAP.get(instance_gpu_brand)
+    dstack_gpu_name = next(
+        iter(gpu_record[1] for gpu_record in GPU_MAP if gpu_record[0] in instance_gpu_brand), None
+    )
     if dstack_gpu_name is None:
         logger.warning(f"Failed to find GPU name matching '{instance_gpu_brand}'")
         return []
@@ -57,11 +59,11 @@ def generate_instances(instance) -> list[RawCatalogItem]:
     return instance_types
 
 
-GPU_MAP = {
-    r"RTX 4090": "RTX4090",
-    r"RTX 5090": "RTX5090",
-    r"RTX 6000 Pro": "RTX6000PRO",
-}
+GPU_MAP = [
+    ("RTX 4090", "RTX4090"),
+    ("RTX 5090", "RTX5090"),
+    ("RTX PRO 6000", "RTXPRO6000"),
+]
 
 
 def _make_request(endpoint: str, request_data: dict) -> Union[dict, str, None]:

--- a/src/gpuhunt/providers/cloudrift.py
+++ b/src/gpuhunt/providers/cloudrift.py
@@ -9,7 +9,7 @@ from gpuhunt.providers import AbstractProvider
 logger = logging.getLogger(__name__)
 
 CLOUDRIFT_SERVER_ADDRESS = "https://api.cloudrift.ai"
-CLOUDRIFT_API_VERSION = "2025-03-21"
+CLOUDRIFT_API_VERSION = "2025-08-07"
 
 
 class CloudRiftProvider(AbstractProvider):

--- a/src/integrity_tests/test_cloudrift.py
+++ b/src/integrity_tests/test_cloudrift.py
@@ -11,8 +11,7 @@ def data_rows(catalog_dir: Path) -> list[dict]:
         return list(csv.DictReader(f))
 
 
-# TODO: Add RTX5090 and RTX6000PRO and others after evaluation
-@pytest.mark.parametrize("gpu", ["RTX4090"])
+@pytest.mark.parametrize("gpu", ["RTX4090", "RTX5090"])
 def test_gpu_present(gpu: str, data_rows: list[dict]):
     assert gpu in map(itemgetter("gpu_name"), data_rows)
 


### PR DESCRIPTION
Fix `gpuhunt` test by setting correct API version.

Recently endpoint used by `gpuhunt` got updated and version has changed.