### PR TITLE
Add GCP A4 instances

### DIFF
--- a/src/integrity_tests/test_gcp.py
+++ b/src/integrity_tests/test_gcp.py
@@ -140,6 +140,7 @@ class TestGCPCatalog:
 
     def test_gpu_presented(self, data: str):
         gpus = [
+            "B200",
             "H100",
             "A100",
             "L4",


### PR DESCRIPTION
Add spot A4 instances with the B200 GPU. Their
pricing model is slightly different from other
instance types - the price is proportional to the
number of GPUs.

Additionally, remove any on-demand GCP offers that
are not actually available on demand, even if the
API returns on-demand prices. This drops A3 High
instances with less than 8 GPUs from the catalog.

https://github.com/dstackai/dstack/issues/3088