### PR TITLE
[GCP] Support G4 preview instance type

### DIFF
--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -468,7 +468,7 @@ def get_preview_offers() -> list[RawCatalogItem]:
             price=0,
             cpu=48,
             memory=180,
-            gpu_vendor=AcceleratorVendor.GOOGLE.value,
+            gpu_vendor=AcceleratorVendor.NVIDIA.value,
             gpu_count=1,
             gpu_name="RTXPRO6000",
             gpu_memory=96,


### PR DESCRIPTION
Fixes #181

The next step is to support it in `dstack` (https://github.com/dstackai/dstack/issues/3155)