### PR TITLE
Integrate the Nebius billing API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ gcp = [
 # `pip install gpuhunt[nebius]` is expected to fail
 # `pip install gpuhunt[all]` is expected to ignore Nebius
 nebius = [
-    "nebius>=0.2.18,<0.3",
+    "nebius>=0.2.40,<0.3",
 ]
 maybe_nebius = [
     'nebius>=0.2.18,<0.3; python_version>="3.10"',

--- a/src/gpuhunt/_internal/constraints.py
+++ b/src/gpuhunt/_internal/constraints.py
@@ -171,6 +171,7 @@ KNOWN_NVIDIA_GPUS: list[NvidiaGPUInfo] = [
     NvidiaGPUInfo(name="H100", memory=80, compute_capability=(9, 0)),
     NvidiaGPUInfo(name="H100NVL", memory=94, compute_capability=(9, 0)),
     NvidiaGPUInfo(name="H200", memory=141, compute_capability=(9, 0)),
+    NvidiaGPUInfo(name="B200", memory=180, compute_capability=(10, 0)),
     NvidiaGPUInfo(name="L4", memory=24, compute_capability=(8, 9)),
     NvidiaGPUInfo(name="L40", memory=48, compute_capability=(8, 9)),
     NvidiaGPUInfo(name="L40S", memory=48, compute_capability=(8, 9)),

--- a/src/integrity_tests/test_nebius.py
+++ b/src/integrity_tests/test_nebius.py
@@ -11,7 +11,7 @@ def data_rows(catalog_dir: Path) -> list[dict]:
         return list(csv.DictReader(f))
 
 
-@pytest.mark.parametrize("gpu", ["L40S", "H100", "H200", ""])
+@pytest.mark.parametrize("gpu", ["L40S", "H100", "H200", "B200", ""])
 def test_gpu_present(gpu: str, data_rows: list[dict]):
     assert gpu in map(itemgetter("gpu_name"), data_rows)
 


### PR DESCRIPTION
Drop hardcoded prices and fetch them from the recently introduced billing API. There are now no hardcoded values in the implementation, so future offers will automatically appear in the catalog with correct prices (although new platforms will be filtered out in dstack).

The billing API requires making a separate request to get the price for each offer. Currently, there are only 70 offers, so this does not take too much time (around 20 seconds) and does not hit any rate limits. The implementation may become more fragile as Nebius expands, but this still seems to be the lesser evil compared to hardcoding prices.

New catalogs are equivalent to old ones, except they also include one spot B200 offer that was not hardcoded in the previous implementation.