### PR TITLE
[Nebius]: Add fabrics list to provider_data

### DIFF
--- a/src/integrity_tests/test_nebius.py
+++ b/src/integrity_tests/test_nebius.py
@@ -1,4 +1,5 @@
 import csv
+import json
 from operator import itemgetter
 from pathlib import Path
 
@@ -28,3 +29,41 @@ def test_spots_presented(data_rows: list[dict]):
 @pytest.mark.parametrize("location", ["eu-north1", "eu-west1"])
 def test_location_present(location: str, data_rows: list[dict]):
     assert location in map(itemgetter("location"), data_rows)
+
+
+def test_fabrics_unique(data_rows: list[dict]) -> None:
+    for row in data_rows:
+        fabrics = json.loads(row["provider_data"])["fabrics"]
+        assert len(fabrics) == len(set(fabrics)), f"Duplicate fabrics in row: {row}"
+
+
+def test_fabrics_on_sample_offer(data_rows: list[dict]) -> None:
+    for row in data_rows:
+        if (
+            row["instance_name"] == "gpu-h100-sxm 8gpu-128vcpu-1600gb"
+            and row["location"] == "eu-north1"
+        ):
+            break
+    else:
+        raise ValueError("Offer not found")
+    fabrics = set(json.loads(row["provider_data"])["fabrics"])
+    expected_fabrics = {
+        "fabric-2",
+        "fabric-3",
+        "fabric-4",
+        "fabric-6",
+    }
+    missing_fabrics = expected_fabrics - fabrics
+    assert not missing_fabrics
+
+
+def test_no_fabrics_on_sample_non_clustered_offer(data_rows: list[dict]) -> None:
+    for row in data_rows:
+        if (
+            row["instance_name"] == "gpu-h100-sxm 1gpu-16vcpu-200gb"
+            and row["location"] == "eu-north1"
+        ):
+            break
+    else:
+        raise ValueError("Offer not found")
+    assert json.loads(row["provider_data"])["fabrics"] == []


### PR DESCRIPTION
Associate each Nebius catalog item with a list of
InfiniBand fabrics that it supports. The list of
fabrics and their details is hardcoded until
Nebius exposes it in the API.

Previously, the list of fabrics was hardcoded in
dstack. Moving it to gpuhunt allows to add new
fabrics without a dstack release.

See also https://github.com/dstackai/dstack/pull/3234