### PR TITLE
Fix collecting GCP catalog

### DIFF
--- a/src/gpuhunt/providers/gcp.py
+++ b/src/gpuhunt/providers/gcp.py
@@ -463,7 +463,10 @@ class Prices:
 
         # For others, the price consists of several components
         price = 0
-        if region_capacity_type not in self.cpu[vm_family]:
+        if (
+            region_capacity_type not in self.cpu[vm_family]
+            or region_capacity_type not in self.ram[vm_family]
+        ):
             return None
         price += instance.cpu * self.cpu[vm_family][region_capacity_type]
         price += instance.memory * self.ram[vm_family][region_capacity_type]


### PR DESCRIPTION
The SKUs returned by the GCP API seem to be
incomplete, as price for the C4A RAM in Warsaw is
missing. Ignore such cases so that they do not
result in catalog collection errors. The C4A
instance family is not used in dstack.