### PR TITLE
Drop verda ICE-01 region

### DIFF
--- a/src/integrity_tests/test_verda.py
+++ b/src/integrity_tests/test_verda.py
@@ -23,7 +23,6 @@ def test_locations(data_rows):
         "FIN-01",
         "FIN-02",
         "FIN-02",
-        "ICE-01",
     }
     locations = select_row(data_rows, "location")
     missing = expected - set(locations)


### PR DESCRIPTION
It disappeared from verda console so we'll work without it as well.

Update: ICE-01 is gone.