### PR TITLE
Add gpuhunt user agent to Nebius SDK

### DIFF
--- a/src/gpuhunt/providers/nebius.py
+++ b/src/gpuhunt/providers/nebius.py
@@ -39,6 +39,7 @@ from gpuhunt._internal.models import (
     RawCatalogItem,
 )
 from gpuhunt.providers import AbstractProvider
+from gpuhunt.version import __version__
 
 logger = logging.getLogger(__name__)
 TIMEOUT = 7
@@ -82,7 +83,10 @@ class NebiusProvider(AbstractProvider):
         self, query_filter: QueryFilter | None = None, balance_resources: bool = True
     ) -> list[RawCatalogItem]:
         items: list[RawCatalogItem] = []
-        sdk = SDK(credentials=self.credentials)
+        sdk = SDK(
+            credentials=self.credentials,
+            user_agent_prefix=f"gpuhunt/{__version__}",
+        )
         calculator = CalculatorServiceClient(sdk)
         try:
             region_to_project_id = get_sample_projects(sdk)

--- a/src/tests/providers/test_nebius.py
+++ b/src/tests/providers/test_nebius.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+from gpuhunt.providers import nebius
+
+
+def test_user_agent_prefix(mocker):
+    sdk_cls = mocker.patch.object(nebius, "SDK")
+    mocker.patch.object(nebius, "CalculatorServiceClient")
+    mocker.patch.object(nebius, "get_sample_projects", return_value={})
+    mocker.patch.object(nebius, "__version__", "1.2.3")
+    credentials = MagicMock()
+
+    nebius.NebiusProvider(credentials).get()
+
+    sdk_cls.assert_called_once_with(
+        credentials=credentials,
+        user_agent_prefix="gpuhunt/1.2.3",
+    )


### PR DESCRIPTION
## Summary

- prefix Nebius SDK requests with `gpuhunt/<version>`
- cover the configured prefix with a focused unit test

## Testing

- `pytest src/tests/providers/test_nebius.py -q`
- `ruff check src/gpuhunt/providers/nebius.py src/tests/providers/test_nebius.py`
- `ruff format --check src/gpuhunt/providers/nebius.py src/tests/providers/test_nebius.py`
